### PR TITLE
security: migrate sandbox to subdomain for cross-origin isolation

### DIFF
--- a/public/sandbox/sw.js
+++ b/public/sandbox/sw.js
@@ -5,6 +5,11 @@ const DEBUG = true
 const log = (...args) => DEBUG && console.log(...args)
 const warn = (...args) => DEBUG && console.warn(...args)
 
+// Detect environment for path prefix
+// Localhost uses /sandbox/run/, subdomain uses /run/
+const isLocalhost = self.location.hostname === "localhost" || self.location.hostname === "127.0.0.1"
+const RUN_PATH_PREFIX = isLocalhost ? "/sandbox/run" : "/run"
+
 const CACHE_NAME = "codescape-sandbox-v3"
 const FILES_CACHE = "codescape-files-v1"
 
@@ -248,11 +253,10 @@ self.addEventListener("message", async (event) => {
             if (blob.type !== type) blob = new Blob([blob], { type })
           }
 
-          // Construct Cache Key: /sandbox/run/<scapeId>/<filename>
+          // Construct Cache Key using environment-aware prefix
           // Note: file.name might contain subdirectories e.g. "css/style.css"
           // We must ensure it matches the fetch request URL exactly.
-          // The fetch handler sees: /sandbox/run/<scapeId>/<normalizedPath>
-          const cacheUrl = new URL(`/sandbox/run/${scapeId}/${file.name}`, self.location.origin)
+          const cacheUrl = new URL(`${RUN_PATH_PREFIX}/${scapeId}/${file.name}`, self.location.origin)
 
           await cache.put(
             cacheUrl,

--- a/src/hooks/usePreviewBridge.ts
+++ b/src/hooks/usePreviewBridge.ts
@@ -54,19 +54,19 @@ export function usePreviewBridge(
   const [prevFilesHash, setPrevFilesHash] = useState(filesHash)
 
   const [bridgeState, setBridgeState] = useState<PreviewBridge>(() => {
-    let bootloaderOrigin = ""
+    let bootloaderUrl = ""
     const currentHost = window.location.hostname
-    if (currentHost === "localhost" || currentHost === "127.0.0.1") {
-      bootloaderOrigin = `${window.location.protocol}//localhost:3002`
-    } else {
-      bootloaderOrigin = `https://sandbox.codescapes.io`
-    }
     const version = versionKey || Date.now()
     const hash = computeHash(filesHash)
+    if (currentHost === "localhost" || currentHost === "127.0.0.1") {
+      bootloaderUrl = `${window.location.protocol}//localhost:3002/sandbox/bootloader.html?v=${version}&h=${hash}`
+    } else {
+      bootloaderUrl = `https://sandbox.codescapes.io/bootloader.html?v=${version}&h=${hash}`
+    }
     return {
       ready: false,
       contentReady: false,
-      url: `${bootloaderOrigin}/sandbox/bootloader.html?v=${version}&h=${hash}`,
+      url: bootloaderUrl,
     }
   })
 
@@ -81,17 +81,15 @@ export function usePreviewBridge(
       setPrevVersionKey(versionKey)
       setPrevFilesHash(filesHash)
 
-      let bootloaderOrigin = ""
+      let bootloaderUrl = ""
       const currentHost = window.location.hostname
-      if (currentHost === "localhost" || currentHost === "127.0.0.1") {
-        bootloaderOrigin = `${window.location.protocol}//localhost:3002`
-      } else {
-        bootloaderOrigin = `https://sandbox.codescapes.io`
-      }
-
       const version = versionKey ?? 0
       const hash = computeHash(filesHash)
-      const bootloaderUrl = `${bootloaderOrigin}/sandbox/bootloader.html?v=${version}&h=${hash}`
+      if (currentHost === "localhost" || currentHost === "127.0.0.1") {
+        bootloaderUrl = `${window.location.protocol}//localhost:3002/sandbox/bootloader.html?v=${version}&h=${hash}`
+      } else {
+        bootloaderUrl = `https://sandbox.codescapes.io/bootloader.html?v=${version}&h=${hash}`
+      }
 
       setBridgeState({ ready: false, contentReady: false, url: bootloaderUrl })
     }

--- a/src/hooks/usePreviewBridge.ts
+++ b/src/hooks/usePreviewBridge.ts
@@ -59,7 +59,7 @@ export function usePreviewBridge(
     if (currentHost === "localhost" || currentHost === "127.0.0.1") {
       bootloaderOrigin = `${window.location.protocol}//localhost:3002`
     } else {
-      bootloaderOrigin = window.location.origin
+      bootloaderOrigin = `https://sandbox.codescapes.io`
     }
     const version = versionKey || Date.now()
     const hash = computeHash(filesHash)
@@ -86,7 +86,7 @@ export function usePreviewBridge(
       if (currentHost === "localhost" || currentHost === "127.0.0.1") {
         bootloaderOrigin = `${window.location.protocol}//localhost:3002`
       } else {
-        bootloaderOrigin = window.location.origin
+        bootloaderOrigin = `https://sandbox.codescapes.io`
       }
 
       const version = versionKey ?? 0
@@ -128,7 +128,7 @@ export function usePreviewBridge(
     if (currentHost === "localhost" || currentHost === "127.0.0.1") {
       bootloaderOrigin = `${window.location.protocol}//localhost:3002`
     } else {
-      bootloaderOrigin = window.location.origin
+      bootloaderOrigin = `https://sandbox.codescapes.io`
     }
 
     // 2. Setup Handshake Listener
@@ -214,7 +214,7 @@ export function usePreviewBridge(
         if (currentHost === "localhost" || currentHost === "127.0.0.1") {
           bootloaderOrigin = `${window.location.protocol}//localhost:3002`
         } else {
-          bootloaderOrigin = window.location.origin
+          bootloaderOrigin = `https://sandbox.codescapes.io`
         }
 
         debug.log("[Bridge] Hot Swapping Files...")


### PR DESCRIPTION
- Update usePreviewBridge.ts to use sandbox.codescapes.io in production
- Fixes critical vulnerability where allow-scripts + allow-same-origin on same origin allowed sandbox escape