### PR TITLE
feat: add global status bar with network and SW indicators

### DIFF
--- a/src/components/StatusBar/StatusBar.tsx
+++ b/src/components/StatusBar/StatusBar.tsx
@@ -1,0 +1,128 @@
+import { Wifi, WifiOff, Zap, AlertTriangle, Cloud, Database, RefreshCw } from "lucide-react"
+import { useAppStatus } from "@/hooks/useAppStatus"
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+export interface StatusBarProps {
+  source?: "local" | "cloud"
+  environment?: string
+  className?: string
+}
+
+export function StatusBar({ source = "local", environment = "web", className }: StatusBarProps) {
+  const { isOnline, swStatus, hasUpdate, updateServiceWorker } = useAppStatus()
+
+  const envLabels: Record<string, string> = {
+    web: "Web",
+    python: "Python",
+    flowscape: "FlowScape",
+    node: "Node",
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex h-6 items-center justify-between border-t bg-muted/50 px-3 text-xs text-muted-foreground",
+        className
+      )}
+    >
+      {/* Left side - Status indicators */}
+      <div className="flex items-center gap-3">
+        {/* Network Status */}
+        <div
+          className="flex cursor-default items-center gap-1.5"
+          title={isOnline ? "Connected to internet" : "No internet connection"}
+        >
+          {isOnline ? (
+            <>
+              <Wifi className="h-3.5 w-3.5 text-green-500" />
+              <span className="hidden sm:inline">Online</span>
+            </>
+          ) : (
+            <>
+              <WifiOff className="h-3.5 w-3.5 text-yellow-500" />
+              <span className="hidden text-yellow-500 sm:inline">Offline</span>
+            </>
+          )}
+        </div>
+
+        {/* Service Worker Status */}
+        <div
+          className="flex cursor-default items-center gap-1.5"
+          title={
+            swStatus === "active"
+              ? "Service Worker running"
+              : swStatus === "installing"
+                ? "Installing new version..."
+                : swStatus === "waiting"
+                  ? "New version ready - click Apply Update"
+                  : "Service Worker error"
+          }
+        >
+          {swStatus === "active" && (
+            <>
+              <Zap className="h-3.5 w-3.5 text-green-500" />
+              <span className="hidden sm:inline">SW Active</span>
+            </>
+          )}
+          {swStatus === "installing" && (
+            <>
+              <RefreshCw className="h-3.5 w-3.5 animate-spin text-blue-500" />
+              <span className="hidden text-blue-500 sm:inline">Updating...</span>
+            </>
+          )}
+          {swStatus === "waiting" && (
+            <>
+              <RefreshCw className="h-3.5 w-3.5 text-yellow-500" />
+              <span className="hidden text-yellow-500 sm:inline">Update Ready</span>
+            </>
+          )}
+          {(swStatus === "error" || swStatus === "unsupported") && (
+            <>
+              <AlertTriangle className="h-3.5 w-3.5 text-red-500" />
+              <span className="hidden text-red-500 sm:inline">SW Error</span>
+            </>
+          )}
+        </div>
+
+        {/* Update button (if update available) */}
+        {hasUpdate && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-5 px-2 text-xs text-yellow-600 hover:text-yellow-700"
+            onClick={updateServiceWorker}
+          >
+            Apply Update
+          </Button>
+        )}
+      </div>
+
+      {/* Right side - Meta info */}
+      <div className="flex items-center gap-3">
+        {/* Source */}
+        <div
+          className="flex cursor-default items-center gap-1.5"
+          title={source === "cloud" ? "Synced to cloud" : "Stored locally"}
+        >
+          {source === "cloud" ? (
+            <>
+              <Cloud className="h-3.5 w-3.5 text-blue-500" />
+              <span className="hidden sm:inline">Cloud</span>
+            </>
+          ) : (
+            <>
+              <Database className="h-3.5 w-3.5" />
+              <span className="hidden sm:inline">Local</span>
+            </>
+          )}
+        </div>
+
+        {/* Environment */}
+        <span className="rounded bg-secondary px-1.5 py-0.5 text-[10px] font-medium">
+          {envLabels[environment] || environment}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/StatusBar/index.ts
+++ b/src/components/StatusBar/index.ts
@@ -1,0 +1,1 @@
+export { StatusBar, type StatusBarProps } from "./StatusBar"

--- a/src/hooks/useAppStatus.ts
+++ b/src/hooks/useAppStatus.ts
@@ -1,0 +1,117 @@
+import { useState, useEffect, useCallback } from "react"
+
+export interface AppStatus {
+  // Network
+  isOnline: boolean
+
+  // Service Worker
+  swStatus: "active" | "installing" | "waiting" | "error" | "unsupported"
+  swVersion: string | null
+  hasUpdate: boolean
+
+  // Methods
+  updateServiceWorker: () => Promise<void>
+}
+
+export function useAppStatus(): AppStatus {
+  const [isOnline, setIsOnline] = useState(navigator.onLine)
+  const [swStatus, setSwStatus] = useState<AppStatus["swStatus"]>(
+    "serviceWorker" in navigator ? "active" : "unsupported"
+  )
+  const [swVersion, setSwVersion] = useState<string | null>(null)
+  const [hasUpdate, setHasUpdate] = useState(false)
+  const [registration, setRegistration] = useState<ServiceWorkerRegistration | null>(null)
+
+  // Network status
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true)
+    const handleOffline = () => setIsOnline(false)
+
+    window.addEventListener("online", handleOnline)
+    window.addEventListener("offline", handleOffline)
+
+    return () => {
+      window.removeEventListener("online", handleOnline)
+      window.removeEventListener("offline", handleOffline)
+    }
+  }, [])
+
+  // Service Worker status
+  useEffect(() => {
+    if (!("serviceWorker" in navigator)) {
+      return
+    }
+
+    const checkSWStatus = async () => {
+      try {
+        const reg = await navigator.serviceWorker.getRegistration()
+        setRegistration(reg || null)
+
+        if (!reg) {
+          setSwStatus("error")
+          return
+        }
+
+        if (reg.installing) {
+          setSwStatus("installing")
+        } else if (reg.waiting) {
+          setSwStatus("waiting")
+          setHasUpdate(true)
+        } else if (reg.active) {
+          setSwStatus("active")
+        }
+
+        // Listen for updates
+        reg.addEventListener("updatefound", () => {
+          setSwStatus("installing")
+          const newWorker = reg.installing
+          if (newWorker) {
+            newWorker.addEventListener("statechange", () => {
+              if (newWorker.state === "installed" && navigator.serviceWorker.controller) {
+                setSwStatus("waiting")
+                setHasUpdate(true)
+              }
+            })
+          }
+        })
+
+        // Get SW version via message
+        if (reg.active) {
+          const messageChannel = new MessageChannel()
+          messageChannel.port1.onmessage = (event) => {
+            if (event.data?.version) {
+              setSwVersion(event.data.version)
+            }
+          }
+          reg.active.postMessage({ type: "GET_VERSION" }, [messageChannel.port2])
+        }
+      } catch (e) {
+        console.error("[useAppStatus] SW check failed:", e)
+        setSwStatus("error")
+      }
+    }
+
+    // Check immediately and when controller changes
+    checkSWStatus()
+
+    navigator.serviceWorker.addEventListener("controllerchange", () => {
+      setSwStatus("active")
+      setHasUpdate(false)
+    })
+  }, [])
+
+  // Update SW method
+  const updateServiceWorker = useCallback(async () => {
+    if (registration?.waiting) {
+      registration.waiting.postMessage({ type: "SKIP_WAITING" })
+    }
+  }, [registration])
+
+  return {
+    isOnline,
+    swStatus,
+    swVersion,
+    hasUpdate,
+    updateServiceWorker,
+  }
+}

--- a/src/layouts/ScapeLayout.tsx
+++ b/src/layouts/ScapeLayout.tsx
@@ -6,6 +6,7 @@ interface ScapeLayoutProps {
   headerActions?: React.ReactNode
   headerTitle?: React.ReactNode
   headerEndActions?: React.ReactNode
+  footer?: React.ReactNode
 }
 
 export function ScapeLayout({
@@ -14,6 +15,7 @@ export function ScapeLayout({
   headerActions,
   headerTitle,
   headerEndActions,
+  footer,
 }: ScapeLayoutProps) {
   return (
     <div className="flex h-screen flex-col overflow-hidden bg-background text-foreground">
@@ -22,6 +24,7 @@ export function ScapeLayout({
         {sidebar}
         <main className="flex-1 overflow-hidden">{children}</main>
       </div>
+      {footer}
     </div>
   )
 }

--- a/src/pages/FlowEditor.tsx
+++ b/src/pages/FlowEditor.tsx
@@ -24,6 +24,7 @@ import type { ActivityTool } from "@/components/layout/EditorActivityBar"
 import { CodeScapeLogo } from "@/components/brand/Logo"
 import { useFlowStore, initAutosave } from "@/stores/flowStore"
 import { SpritePane } from "@/components/editor/SpritePane"
+import { StatusBar } from "@/components/StatusBar"
 
 const StopIcon = ({ className }: { className?: string }) => (
   <div
@@ -471,6 +472,9 @@ export default function FlowEditor() {
           </ResizablePanel>
         </ResizablePanelGroup>
       </div>
+
+      {/* 3. STATUS BAR */}
+      <StatusBar source={source as "local" | "cloud"} environment="flowscape" />
     </div>
   )
 }

--- a/src/pages/ScapeEditor.tsx
+++ b/src/pages/ScapeEditor.tsx
@@ -15,6 +15,7 @@ import { TerminalPane, type TerminalTab } from "@/components/editor/TerminalPane
 import { EditorActivityBar } from "@/components/layout/EditorActivityBar"
 import { SecretsPanel } from "@/components/secrets/SecretsPanel"
 import { SaveStatus } from "@/components/editor/SaveStatus"
+import { StatusBar } from "@/components/StatusBar"
 import { ShareDialog } from "@/components/editor/ShareDialog"
 import type { ScapeFile } from "@/types/file"
 import type { Problem } from "@/types/problem"
@@ -1007,6 +1008,7 @@ export default function ScapeEditor() {
             Exit
           </Button>
         }
+        footer={<StatusBar source={source as "local" | "cloud"} environment={scape?.environment} />}
       >
         <ResizablePanelGroup
           ref={mainLayoutGroupRef}
@@ -1062,7 +1064,7 @@ export default function ScapeEditor() {
                     scapeId={id}
                     isOpen={true}
                     ref={secretsPanelRef}
-                  // ref={secretsPanelRef} // TODO: Expose handlePasteEnv via ref in component
+                    // ref={secretsPanelRef} // TODO: Expose handlePasteEnv via ref in component
                   />
                 )}
               </ResizablePanel>


### PR DESCRIPTION
- Add useAppStatus hook to track network connectivity and Service Worker status
- Create StatusBar component showing online/offline, SW active/updating/error states
- Update ScapeLayout with footer prop for status bar placement
- Integrate StatusBar into ScapeEditor and FlowEditor
- Show source (local/cloud) and environment badges in status bar