### PR TITLE
feat: implement VS Code-style search with find and replace

### DIFF
--- a/src/components/editor/CodeEditor.tsx
+++ b/src/components/editor/CodeEditor.tsx
@@ -80,6 +80,9 @@ export function CodeEditor({
   }, [monaco, files, fileName])
 
   const handleEditorDidMount: OnMount = (editor, monaco) => {
+    // Store editor reference for external content sync
+    editorRef.current = editor
+
     // Basic configuration
     editor.updateOptions({
       minimap: { enabled: false },
@@ -115,17 +118,26 @@ export function CodeEditor({
     })
   }
 
-  // Handle File Switching Manually
-  // When fileName changes, we want to update the editor content.
-  // When initialValue changes BUT fileName is the same, we ignore it (user is typing).
-  const lastFileName = useRef(fileName)
+  // Sync external content changes to Monaco
+  // This handles cases like search/replace updating file content
+  const editorRef = useRef<Parameters<OnMount>[0] | null>(null)
+  const lastExternalValue = useRef(initialValue)
+
   useEffect(() => {
-    if (fileName !== lastFileName.current) {
-      // File changed, update content
-      // Monaco handles this via 'path' prop mostly, but explicit check helps if using same model
-      lastFileName.current = fileName
+    if (!editorRef.current) return
+
+    const currentModelValue = editorRef.current.getValue()
+
+    // Only sync if:
+    // 1. The initialValue changed
+    // 2. The change isn't from the editor itself (content differs from model)
+    if (initialValue !== lastExternalValue.current && initialValue !== currentModelValue) {
+      // This is an external change, sync it to the editor
+      editorRef.current.setValue(initialValue)
     }
-  }, [fileName, initialValue])
+
+    lastExternalValue.current = initialValue
+  }, [initialValue])
 
   const handleValidate: OnValidate = (markers) => {
     if (!onValidate) return

--- a/src/components/editor/SearchPane.tsx
+++ b/src/components/editor/SearchPane.tsx
@@ -1,0 +1,417 @@
+import { useState, useCallback, useMemo, useEffect, useRef } from "react"
+import {
+  Search,
+  Replace,
+  ChevronRight,
+  ChevronDown,
+  FileCode,
+  CaseSensitive,
+  Regex,
+  WholeWord,
+  X,
+} from "lucide-react"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { cn } from "@/lib/utils"
+import {
+  searchFiles,
+  replaceInFile,
+  replaceInFiles,
+  replaceSingleMatch,
+  type SearchOptions,
+  type FileSearchResult,
+  type SearchMatch,
+} from "@/lib/search"
+import type { ScapeFile } from "@/types/file"
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface SearchPaneProps {
+  files: ScapeFile[]
+  onNavigate: (fileName: string, line?: number) => void
+  onUpdateFile: (fileName: string, content: string) => void
+  className?: string
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function SearchPane({ files, onNavigate, onUpdateFile, className }: SearchPaneProps) {
+  // Search state
+  const [query, setQuery] = useState("")
+  const [replacement, setReplacement] = useState("")
+  const [showReplace, setShowReplace] = useState(false)
+
+  // Options
+  const [caseSensitive, setCaseSensitive] = useState(false)
+  const [useRegex, setUseRegex] = useState(false)
+  const [wholeWord, setWholeWord] = useState(false)
+
+  // UI state - track expanded files
+  const [expandedFiles, setExpandedFiles] = useState<Set<string>>(new Set())
+  const searchInputRef = useRef<HTMLInputElement>(null)
+
+  // Focus search input on mount
+  useEffect(() => {
+    searchInputRef.current?.focus()
+  }, [])
+
+  // Build search options
+  const options: SearchOptions = useMemo(
+    () => ({
+      caseSensitive,
+      regex: useRegex,
+      wholeWord,
+      maxResultsPerFile: 100,
+      maxTotalResults: 500,
+    }),
+    [caseSensitive, useRegex, wholeWord]
+  )
+
+  // Perform search
+  const searchResults = useMemo(() => {
+    if (!query.trim()) {
+      return { results: [], totalMatches: 0, truncated: false }
+    }
+    return searchFiles(files, query, options)
+  }, [files, query, options])
+
+  // Check if file should be expanded (auto-expand single file result)
+  const isFileExpanded = useCallback(
+    (fileName: string) => {
+      // Auto-expand if only 1 file with results
+      if (searchResults.results.length === 1) {
+        return true
+      }
+      return expandedFiles.has(fileName)
+    },
+    [expandedFiles, searchResults.results.length]
+  )
+
+  // Toggle file expansion
+  const toggleFile = useCallback((fileName: string) => {
+    setExpandedFiles((prev) => {
+      const next = new Set(prev)
+      if (next.has(fileName)) {
+        next.delete(fileName)
+      } else {
+        next.add(fileName)
+      }
+      return next
+    })
+  }, [])
+
+  // Handle result click
+  const handleMatchClick = useCallback(
+    (fileName: string, line: number) => {
+      onNavigate(fileName, line)
+    },
+    [onNavigate]
+  )
+
+  // Replace single match
+  const handleReplaceSingle = useCallback(
+    (fileResult: FileSearchResult, match: SearchMatch) => {
+      if (typeof fileResult.file.content !== "string") return
+
+      const newContent = replaceSingleMatch(fileResult.file.content, match, replacement)
+      onUpdateFile(fileResult.file.name, newContent)
+    },
+    [replacement, onUpdateFile]
+  )
+
+  // Replace all in file
+  const handleReplaceInFile = useCallback(
+    (fileResult: FileSearchResult) => {
+      if (typeof fileResult.file.content !== "string") return
+
+      const { newContent } = replaceInFile(fileResult.file.content, query, replacement, options)
+      onUpdateFile(fileResult.file.name, newContent)
+    },
+    [query, replacement, options, onUpdateFile]
+  )
+
+  // Replace all across all files
+  const handleReplaceAll = useCallback(() => {
+    const results = replaceInFiles(files, query, replacement, options)
+    for (const result of results) {
+      onUpdateFile(result.file.name, result.newContent)
+    }
+  }, [files, query, replacement, options, onUpdateFile])
+
+  // Clear search
+  const handleClear = useCallback(() => {
+    setQuery("")
+    setReplacement("")
+    searchInputRef.current?.focus()
+  }, [])
+
+  // Keyboard handler
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === "Escape") {
+        handleClear()
+      }
+    },
+    [handleClear]
+  )
+
+  return (
+    <div className={cn("flex h-full flex-col", className)} onKeyDown={handleKeyDown}>
+      {/* Header */}
+      <div className="flex items-center justify-between border-b px-3 py-2">
+        <span className="text-sm font-medium">Search</span>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            className={cn("h-6 w-6 p-0", showReplace && "bg-accent")}
+            onClick={() => setShowReplace(!showReplace)}
+            title="Toggle Replace"
+          >
+            <Replace className="h-3.5 w-3.5" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Search Input */}
+      <div className="space-y-2 border-b px-3 py-2">
+        <div className="flex items-center gap-1">
+          <div className="relative flex-1">
+            <Search className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+            <Input
+              ref={searchInputRef}
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search"
+              className="h-7 pl-7 pr-7 text-sm"
+            />
+            {query && (
+              <Button
+                variant="ghost"
+                size="sm"
+                className="absolute right-0 top-1/2 h-6 w-6 -translate-y-1/2 p-0"
+                onClick={handleClear}
+              >
+                <X className="h-3 w-3" />
+              </Button>
+            )}
+          </div>
+
+          {/* Option toggles */}
+          <Button
+            variant="ghost"
+            size="sm"
+            className={cn("h-7 w-7 p-0", caseSensitive && "bg-accent text-accent-foreground")}
+            onClick={() => setCaseSensitive(!caseSensitive)}
+            title="Match Case"
+          >
+            <CaseSensitive className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className={cn("h-7 w-7 p-0", wholeWord && "bg-accent text-accent-foreground")}
+            onClick={() => setWholeWord(!wholeWord)}
+            title="Match Whole Word"
+          >
+            <WholeWord className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className={cn("h-7 w-7 p-0", useRegex && "bg-accent text-accent-foreground")}
+            onClick={() => setUseRegex(!useRegex)}
+            title="Use Regular Expression"
+          >
+            <Regex className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Replace Input */}
+        {showReplace && (
+          <div className="flex items-center gap-1">
+            <div className="relative flex-1">
+              <Replace className="absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+              <Input
+                value={replacement}
+                onChange={(e) => setReplacement(e.target.value)}
+                placeholder="Replace"
+                className="h-7 pl-7 text-sm"
+              />
+            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-7 px-2 text-xs"
+              onClick={handleReplaceAll}
+              disabled={!query || searchResults.totalMatches === 0}
+              title="Replace All"
+            >
+              All
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Results summary */}
+      {query && (
+        <div className="border-b px-3 py-1.5 text-xs text-muted-foreground">
+          {searchResults.totalMatches === 0 ? (
+            "No results found"
+          ) : (
+            <>
+              {searchResults.totalMatches} result{searchResults.totalMatches !== 1 ? "s" : ""} in{" "}
+              {searchResults.results.length} file{searchResults.results.length !== 1 ? "s" : ""}
+              {searchResults.truncated && " (truncated)"}
+            </>
+          )}
+        </div>
+      )}
+
+      {/* Results Tree */}
+      <div className="flex-1 overflow-auto">
+        {searchResults.results.map((fileResult) => (
+          <FileResult
+            key={fileResult.file.name}
+            fileResult={fileResult}
+            isExpanded={isFileExpanded(fileResult.file.name)}
+            onToggle={() => toggleFile(fileResult.file.name)}
+            onMatchClick={handleMatchClick}
+            onReplaceSingle={showReplace ? handleReplaceSingle : undefined}
+            onReplaceInFile={showReplace ? handleReplaceInFile : undefined}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}
+
+// ============================================================================
+// File Result Component
+// ============================================================================
+
+interface FileResultProps {
+  fileResult: FileSearchResult
+  isExpanded: boolean
+  onToggle: () => void
+  onMatchClick: (fileName: string, line: number) => void
+  onReplaceSingle?: (fileResult: FileSearchResult, match: SearchMatch) => void
+  onReplaceInFile?: (fileResult: FileSearchResult) => void
+}
+
+function FileResult({
+  fileResult,
+  isExpanded,
+  onToggle,
+  onMatchClick,
+  onReplaceSingle,
+  onReplaceInFile,
+}: FileResultProps) {
+  const fileName = fileResult.file.name
+  const matchCount = fileResult.matches.length
+
+  return (
+    <div className="border-b border-border/50">
+      {/* File header */}
+      <div
+        className="group flex cursor-pointer items-center gap-1 px-2 py-1 hover:bg-accent/50"
+        onClick={onToggle}
+      >
+        {isExpanded ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+        <FileCode className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="flex-1 truncate text-sm">{fileName}</span>
+        <span className="rounded-full bg-muted px-1.5 text-xs text-muted-foreground">
+          {matchCount}
+        </span>
+        {onReplaceInFile && (
+          <Button
+            variant="ghost"
+            size="sm"
+            className="h-5 w-5 p-0 opacity-0 group-hover:opacity-100"
+            onClick={(e) => {
+              e.stopPropagation()
+              onReplaceInFile(fileResult)
+            }}
+            title="Replace All in File"
+          >
+            <Replace className="h-3 w-3" />
+          </Button>
+        )}
+      </div>
+
+      {/* Matches */}
+      {isExpanded && (
+        <div className="pb-1">
+          {fileResult.matches.map((match, index) => (
+            <MatchLine
+              key={`${match.line}-${match.column}-${index}`}
+              match={match}
+              onClick={() => onMatchClick(fileName, match.line)}
+              onReplace={onReplaceSingle ? () => onReplaceSingle(fileResult, match) : undefined}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ============================================================================
+// Match Line Component
+// ============================================================================
+
+interface MatchLineProps {
+  match: SearchMatch
+  onClick: () => void
+  onReplace?: () => void
+}
+
+function MatchLine({ match, onClick, onReplace }: MatchLineProps) {
+  // Highlight the match in the line content
+  const before = match.lineContent.substring(0, match.column)
+  const matched = match.lineContent.substring(match.column, match.column + match.length)
+  const after = match.lineContent.substring(match.column + match.length)
+
+  // Trim context for display
+  const maxContext = 40
+  const displayBefore = before.length > maxContext ? "..." + before.slice(-maxContext) : before
+  const displayAfter = after.length > maxContext ? after.slice(0, maxContext) + "..." : after
+
+  return (
+    <div
+      className="group flex cursor-pointer items-center gap-2 py-0.5 pl-8 pr-2 hover:bg-accent/30"
+      onClick={onClick}
+    >
+      <span className="w-8 shrink-0 text-right text-xs text-muted-foreground">{match.line}</span>
+      <span className="flex-1 truncate font-mono text-xs">
+        <span className="text-muted-foreground">{displayBefore}</span>
+        <span className="rounded bg-yellow-500/30 px-0.5 font-medium text-foreground">
+          {matched}
+        </span>
+        <span className="text-muted-foreground">{displayAfter}</span>
+      </span>
+      {onReplace && (
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-4 w-4 p-0 opacity-0 group-hover:opacity-100"
+          onClick={(e) => {
+            e.stopPropagation()
+            onReplace()
+          }}
+          title="Replace"
+        >
+          <Replace className="h-3 w-3" />
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/useShell.ts
+++ b/src/hooks/useShell.ts
@@ -2,6 +2,7 @@ import { useCallback } from "react"
 import { parseCommand } from "@/lib/shell/parser"
 import type { CommandHandler, ShellContext, ShellOutput } from "@/lib/shell/types"
 import type { ScapeFile } from "@/types/file"
+import { searchFiles } from "@/lib/search"
 
 // Kernel Interface - Needs access to file system hooks
 interface FileSystemHooks {
@@ -99,6 +100,70 @@ const commands: Record<string, CommandHandler> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     await ctx.createFile(args[0], "folder" as any)
     return
+  },
+
+  grep: async (args, ctx) => {
+    // Parse flags
+    let caseInsensitive = false
+    let listFilesOnly = false
+    const patterns: string[] = []
+    const fileFilters: string[] = []
+
+    for (const arg of args) {
+      if (arg === "-i") {
+        caseInsensitive = true
+      } else if (arg === "-l") {
+        listFilesOnly = true
+      } else if (arg.startsWith("-")) {
+        // Ignore unknown flags
+      } else if (patterns.length === 0) {
+        patterns.push(arg)
+      } else {
+        fileFilters.push(arg)
+      }
+    }
+
+    if (patterns.length === 0) {
+      return { type: "error", content: "usage: grep [-i] [-l] <pattern> [file...]" }
+    }
+
+    const pattern = patterns[0]
+
+    // Filter files if specified
+    let filesToSearch = ctx.files
+    if (fileFilters.length > 0) {
+      filesToSearch = ctx.files.filter((f) => fileFilters.some((filter) => f.name.includes(filter)))
+    }
+
+    // Perform search
+    const results = searchFiles(filesToSearch, pattern, {
+      caseSensitive: !caseInsensitive,
+      regex: false,
+      maxTotalResults: 200,
+    })
+
+    if (results.totalMatches === 0) {
+      return { type: "stdout", content: "" }
+    }
+
+    // Format output
+    const lines: string[] = []
+
+    if (listFilesOnly) {
+      // Just list file names
+      for (const fileResult of results.results) {
+        lines.push(fileResult.file.name)
+      }
+    } else {
+      // Show matches with line numbers
+      for (const fileResult of results.results) {
+        for (const match of fileResult.matches) {
+          lines.push(`${fileResult.file.name}:${match.line}:${match.lineContent}`)
+        }
+      }
+    }
+
+    return { type: "stdout", content: lines.join("\n") }
   },
 
   pip: async (args, ctx) => {

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,249 @@
+import type { ScapeFile } from "@/types/file"
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SearchOptions {
+  caseSensitive?: boolean
+  regex?: boolean
+  wholeWord?: boolean
+  maxResultsPerFile?: number
+  maxTotalResults?: number
+}
+
+export interface SearchMatch {
+  line: number // 1-indexed
+  column: number // 0-indexed
+  length: number // Length of the match
+  lineContent: string // Full line content
+  matchText: string // The actual matched text
+}
+
+export interface FileSearchResult {
+  file: ScapeFile
+  matches: SearchMatch[]
+}
+
+export interface SearchResults {
+  results: FileSearchResult[]
+  totalMatches: number
+  truncated: boolean // True if results were capped
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/**
+ * Check if file content is binary (not searchable text)
+ */
+function isBinaryContent(content: ScapeFile["content"]): boolean {
+  return content instanceof Blob || content instanceof ArrayBuffer || content instanceof Uint8Array
+}
+
+/**
+ * Escape special regex characters in a string
+ */
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+/**
+ * Build regex pattern from search query and options
+ */
+function buildPattern(query: string, options: SearchOptions): RegExp | null {
+  if (!query) return null
+
+  let pattern = query
+
+  // If not using regex, escape special characters
+  if (!options.regex) {
+    pattern = escapeRegex(pattern)
+  }
+
+  // Wrap with word boundaries if whole word matching
+  if (options.wholeWord) {
+    pattern = `\\b${pattern}\\b`
+  }
+
+  try {
+    const flags = options.caseSensitive ? "g" : "gi"
+    return new RegExp(pattern, flags)
+  } catch {
+    // Invalid regex
+    return null
+  }
+}
+
+// ============================================================================
+// Main Search Function
+// ============================================================================
+
+/**
+ * Search for text across multiple files
+ *
+ * @param files - Array of ScapeFile objects to search
+ * @param query - Search query (plain text or regex)
+ * @param options - Search options
+ * @returns Structured search results
+ */
+export function searchFiles(
+  files: ScapeFile[],
+  query: string,
+  options: SearchOptions = {}
+): SearchResults {
+  const { maxResultsPerFile = 100, maxTotalResults = 500 } = options
+
+  const pattern = buildPattern(query, options)
+  if (!pattern) {
+    return { results: [], totalMatches: 0, truncated: false }
+  }
+
+  const results: FileSearchResult[] = []
+  let totalMatches = 0
+  let truncated = false
+
+  for (const file of files) {
+    // Skip binary files silently
+    if (isBinaryContent(file.content)) continue
+
+    // Skip folders
+    if (file.language === "folder") continue
+
+    const content = file.content as string
+    const lines = content.split("\n")
+    const matches: SearchMatch[] = []
+
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      const lineContent = lines[lineIndex]
+
+      // Reset regex lastIndex for each line
+      pattern.lastIndex = 0
+
+      let match: RegExpExecArray | null
+      while ((match = pattern.exec(lineContent)) !== null) {
+        // Check limits
+        if (matches.length >= maxResultsPerFile) {
+          truncated = true
+          break
+        }
+        if (totalMatches >= maxTotalResults) {
+          truncated = true
+          break
+        }
+
+        matches.push({
+          line: lineIndex + 1, // 1-indexed
+          column: match.index,
+          length: match[0].length,
+          lineContent: lineContent,
+          matchText: match[0],
+        })
+        totalMatches++
+
+        // Prevent infinite loop for zero-width matches
+        if (match[0].length === 0) {
+          pattern.lastIndex++
+        }
+      }
+
+      if (truncated) break
+    }
+
+    if (matches.length > 0) {
+      results.push({ file, matches })
+    }
+
+    if (truncated) break
+  }
+
+  return { results, totalMatches, truncated }
+}
+
+// ============================================================================
+// Replace Functions
+// ============================================================================
+
+export interface ReplaceResult {
+  file: ScapeFile
+  newContent: string
+  replacementCount: number
+}
+
+/**
+ * Replace all matches in a single file's content
+ */
+export function replaceInFile(
+  content: string,
+  query: string,
+  replacement: string,
+  options: SearchOptions = {}
+): { newContent: string; count: number } {
+  const pattern = buildPattern(query, options)
+  if (!pattern) {
+    return { newContent: content, count: 0 }
+  }
+
+  let count = 0
+  const newContent = content.replace(pattern, () => {
+    count++
+    return replacement
+  })
+
+  return { newContent, count }
+}
+
+/**
+ * Replace all occurrences across multiple files
+ */
+export function replaceInFiles(
+  files: ScapeFile[],
+  query: string,
+  replacement: string,
+  options: SearchOptions = {}
+): ReplaceResult[] {
+  const results: ReplaceResult[] = []
+
+  for (const file of files) {
+    // Skip binary files
+    if (isBinaryContent(file.content)) continue
+    if (file.language === "folder") continue
+
+    const content = file.content as string
+    const { newContent, count } = replaceInFile(content, query, replacement, options)
+
+    if (count > 0) {
+      results.push({
+        file,
+        newContent,
+        replacementCount: count,
+      })
+    }
+  }
+
+  return results
+}
+
+/**
+ * Replace a single match at a specific location
+ */
+export function replaceSingleMatch(
+  content: string,
+  match: SearchMatch,
+  replacement: string
+): string {
+  const lines = content.split("\n")
+  const lineIndex = match.line - 1 // Convert to 0-indexed
+
+  if (lineIndex < 0 || lineIndex >= lines.length) {
+    return content
+  }
+
+  const line = lines[lineIndex]
+  const before = line.substring(0, match.column)
+  const after = line.substring(match.column + match.length)
+  lines[lineIndex] = before + replacement + after
+
+  return lines.join("\n")
+}

--- a/src/pages/ScapeEditor.tsx
+++ b/src/pages/ScapeEditor.tsx
@@ -11,6 +11,7 @@ import { FileExplorer } from "@/components/editor/FileExplorer"
 import { PreviewPane, type PreviewPaneHandle } from "@/components/editor/PreviewPane"
 import { PackagePane } from "@/components/editor/PackagePane"
 import { TerminalPane, type TerminalTab } from "@/components/editor/TerminalPane"
+import { SearchPane } from "@/components/editor/SearchPane"
 
 import { EditorActivityBar } from "@/components/layout/EditorActivityBar"
 import { SecretsPanel } from "@/components/secrets/SecretsPanel"
@@ -1046,9 +1047,14 @@ export default function ScapeEditor() {
                   />
                 )}
                 {activeTool === "search" && (
-                  <div className="flex h-full items-center justify-center p-4 text-muted-foreground">
-                    Search coming soon...
-                  </div>
+                  <SearchPane
+                    files={files}
+                    onNavigate={(fileName) => {
+                      setActiveFilePath(fileName)
+                      // TODO: Navigate to specific line in CodeEditor
+                    }}
+                    onUpdateFile={updateFile}
+                  />
                 )}
                 {/* Dynamically check capabilities before rendering packages UI in sidebar content */}
                 {activeTool === "packages" &&

--- a/tests/file-creation.spec.ts
+++ b/tests/file-creation.spec.ts
@@ -4,7 +4,7 @@ test("File Creation works", async ({ page }) => {
   await page.goto("/dashboard")
 
   // 1. Create a New Scape
-  await page.getByRole("button", { name: "New Scape" }).click()
+  await page.getByRole("button", { name: "New Scape" }).first().click()
   await page.getByRole("textbox", { name: "Scape Name" }).fill("FileCreationTest")
   await page.getByText("Blank ProjectA simple HTML/").click()
   await page.getByRole("button", { name: "Create Scape" }).click()


### PR DESCRIPTION
- Add lib/search.ts with searchFiles, replaceInFile, replaceInFiles
- Create SearchPane component with tree-style results and match highlighting
- Support case-sensitive, whole-word, and regex search modes
- Add replace single, replace in file, and replace all functionality
- Add grep command to terminal shell with -i and -l flags
- Sync CodeEditor with external content changes for instant replace updates
- Result limits: 100 per file, 500 total to prevent performance issues
- Fix flaky E2E test for file creation