### PR TITLE
fix(scapper): robust file operations and path handling

### DIFF
--- a/src/lib/ai/tools.ts
+++ b/src/lib/ai/tools.ts
@@ -208,6 +208,10 @@ export function getToolsForEnvironment(capabilities: {
   return tools
 }
 
+function normalizePath(path: string): string {
+  return path.replace(/^\/+/, "")
+}
+
 // Legacy export for backwards compatibility
 export const SCAPPER_TOOLS = BASE_TOOLS
 
@@ -324,7 +328,7 @@ function executeListFiles(ctx: ToolContext): ToolResult {
 }
 
 function executeReadFile(path: string, ctx: ToolContext): ToolResult {
-  const file = ctx.files.find((f) => f.name === path)
+  const file = ctx.files.find((f) => normalizePath(f.name) === normalizePath(path))
 
   if (!file) {
     return { success: false, output: "", error: `File not found: ${path}` }
@@ -347,7 +351,7 @@ async function executeCreateFile(
   ctx: ToolContext
 ): Promise<ToolResult> {
   // Check if file already exists
-  const existing = ctx.files.find((f) => f.name === path)
+  const existing = ctx.files.find((f) => normalizePath(f.name) === normalizePath(path))
   if (existing) {
     return {
       success: false,
@@ -381,7 +385,7 @@ async function executeEditFile(
   replace: string,
   ctx: ToolContext
 ): Promise<ToolResult> {
-  const fileIndex = ctx.files.findIndex((f) => f.name === path)
+  const fileIndex = ctx.files.findIndex((f) => normalizePath(f.name) === normalizePath(path))
   const file = ctx.files[fileIndex]
 
   if (!file) {
@@ -419,15 +423,23 @@ async function executeOverwriteFile(
   content: string,
   ctx: ToolContext
 ): Promise<ToolResult> {
-  const fileIndex = ctx.files.findIndex((f) => f.name === path)
+  const fileIndex = ctx.files.findIndex((f) => normalizePath(f.name) === normalizePath(path))
   const file = ctx.files[fileIndex]
 
   if (!file) {
+    // If not found, try to create it? No, overwrite implies existing.
+    // But maybe we should be lenient? The prompt says "NEVER use create_file on existing".
+    // Does overwrite_file imply strict replacement?
+    // Let's stick to strict existing check for now, but with normalized path.
     return { success: false, output: "", error: `File not found: ${path}` }
   }
 
+  // Use the actual found name for the callback to ensure exact match if case differs (though we normalized)
+  // Actually, we should probably use the matched file's name for the update to be safe
+  const targetPath = file ? file.name : path
+
   // Call the update callback FIRST
-  await ctx.updateFile(path, content)
+  await ctx.updateFile(targetPath, content)
 
   // Update local context AFTER callback succeeds
   ctx.files[fileIndex] = { ...file, content }
@@ -437,7 +449,7 @@ async function executeOverwriteFile(
 }
 
 async function executeDeleteFile(path: string, ctx: ToolContext): Promise<ToolResult> {
-  const fileIndex = ctx.files.findIndex((f) => f.name === path)
+  const fileIndex = ctx.files.findIndex((f) => normalizePath(f.name) === normalizePath(path))
 
   if (fileIndex === -1) {
     return { success: false, output: "", error: `File not found: ${path}` }

--- a/src/pages/ScapeEditor.tsx
+++ b/src/pages/ScapeEditor.tsx
@@ -744,8 +744,7 @@ export default function ScapeEditor() {
     // ----------------------------
 
     if (files.some((f) => f.name === fileName)) {
-      // alert("File already exists")
-      return
+      throw new Error(`File '${fileName}' already exists`)
     }
 
     let language: ScapeFile["language"] = "javascript"


### PR DESCRIPTION
- handleCreateFile now throws error instead of silent return on collision
- Added normalizePath() to handle /file vs file paths consistently
- Applied normalizePath to all file tools (read, edit, overwrite, create, delete)
- Improved system prompt: ask questions instead of stating capabilities
- Added tool usage examples for smaller models
- Prefer overwrite_file for small files tip