### PR TITLE
feat(r): Implement R package manager with persistence

### DIFF
--- a/src/components/editor/PackagePane.tsx
+++ b/src/components/editor/PackagePane.tsx
@@ -1,12 +1,35 @@
-import { Package, Trash2, Box } from "lucide-react"
+import { Package, Trash2, Box, Loader2 } from "lucide-react"
 import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useState } from "react"
 
 interface PackagePaneProps {
   dependencies: string[]
   onDeletePackage: (pkg: string) => void
+  onInstallPackage?: (pkg: string) => void
+  language?: string
 }
 
-export function PackagePane({ dependencies, onDeletePackage }: PackagePaneProps) {
+export function PackagePane({
+  dependencies,
+  onDeletePackage,
+  onInstallPackage,
+  language,
+}: PackagePaneProps) {
+  const [newPackage, setNewPackage] = useState("")
+  const [isInstalling, setIsInstalling] = useState(false)
+
+  const handleInstall = async () => {
+    if (!newPackage.trim() || !onInstallPackage) return
+    setIsInstalling(true)
+    try {
+      await onInstallPackage(newPackage)
+      setNewPackage("")
+    } finally {
+      setIsInstalling(false)
+    }
+  }
+
   return (
     <div className="flex h-full flex-col">
       <div className="flex items-center gap-2 border-b px-4 py-3 text-sm font-semibold text-muted-foreground">
@@ -18,14 +41,41 @@ export function PackagePane({ dependencies, onDeletePackage }: PackagePaneProps)
       </div>
 
       <div className="flex-1 overflow-auto p-2">
+        {language === "r" && (
+          <div className="mb-4 border-b px-2 pb-4 pt-2">
+            <div className="flex gap-2">
+              <Input
+                value={newPackage}
+                onChange={(e) => setNewPackage(e.target.value)}
+                placeholder="Package name..."
+                className="h-8 text-xs"
+                onKeyDown={(e) => e.key === "Enter" && handleInstall()}
+              />
+              <Button
+                size="sm"
+                onClick={handleInstall}
+                disabled={isInstalling || !newPackage}
+                className="h-8 px-3 text-xs"
+              >
+                {isInstalling ? <Loader2 className="h-3 w-3 animate-spin" /> : "Install"}
+              </Button>
+            </div>
+            <p className="mt-2 text-[10px] text-muted-foreground">
+              Installs binary from r-wasm (CRAN mirror).
+            </p>
+          </div>
+        )}
+
         {dependencies.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-2 pt-10 text-center text-xs text-muted-foreground">
             <Package className="h-8 w-8 opacity-20" />
             <p>No packages install yet.</p>
-            <p className="mt-2 px-4 opacity-75">
-              Use <code className="rounded bg-muted px-1 py-0.5">pip install &lt;name&gt;</code> in
-              the terminal to add packages.
-            </p>
+            {language !== "r" && (
+              <p className="mt-2 px-4 opacity-75">
+                Use <code className="rounded bg-muted px-1 py-0.5">pip install &lt;name&gt;</code>{" "}
+                in the terminal to add packages.
+              </p>
+            )}
           </div>
         ) : (
           <div className="flex flex-col gap-1">

--- a/src/lib/ai/groqClient.ts
+++ b/src/lib/ai/groqClient.ts
@@ -85,7 +85,7 @@ export async function chatCompletion(
     )
   }
 
-  const { model = "llama-3.3-70b-versatile", maxTokens, temperature = 0.3 } = options || {}
+  const { model = "qwen/qwen3-32b", maxTokens, temperature = 0.6 } = options || {}
 
   const body: Record<string, unknown> = {
     model,

--- a/src/pages/ScapeEditor.tsx
+++ b/src/pages/ScapeEditor.tsx
@@ -12,6 +12,7 @@ import { PreviewPane, type PreviewPaneHandle } from "@/components/editor/Preview
 import { PackagePane } from "@/components/editor/PackagePane"
 import { TerminalPane, type TerminalTab } from "@/components/editor/TerminalPane"
 import { SearchPane } from "@/components/editor/SearchPane"
+import { useToast } from "@/components/ui/use-toast"
 
 import { EditorActivityBar } from "@/components/layout/EditorActivityBar"
 import { SecretsPanel } from "@/components/secrets/SecretsPanel"
@@ -139,6 +140,15 @@ export default function ScapeEditor() {
 
   // Optimistic UI for Dependencies
   const [optimisticDependencies, setOptimisticDependencies] = useState<string[] | null>(null)
+  const [installedRPackages, setInstalledRPackages] = useState<string[]>([])
+  const { toast } = useToast()
+
+  // Sync installedRPackages with scape.dependencies for R environments on load
+  useEffect(() => {
+    if (scape?.environment === "r" && scape?.dependencies) {
+      setInstalledRPackages(scape.dependencies)
+    }
+  }, [scape?.environment, scape?.dependencies])
 
   const [debouncedFiles, setDebouncedFiles] = useState<ScapeFile[]>([])
   const [initialPreviewSynced, setInitialPreviewSynced] = useState(false)
@@ -372,6 +382,60 @@ export default function ScapeEditor() {
     }
   }, [setIsTerminalOpen, setTerminalTab])
 
+  const handleInstallPackage = useCallback(
+    async (pkg: string, language?: string) => {
+      // Only R supports our custom install flow for now
+      if (language !== "r" && language !== "python") return
+
+      // For Python, we just show the help text (handled by component), but if we ever support pip...
+      if (language === "python") {
+        return
+      }
+
+      if (!previewRef.current?.installPackage) {
+        toast({
+          title: "Error",
+          description: "Package installation not supported in this environment",
+          variant: "destructive",
+        })
+        return
+      }
+
+      toast({ title: "Installing...", description: `Installing ${pkg}, this may take a moment.` })
+      try {
+        const result = await previewRef.current.installPackage(pkg)
+        if (!result.success) {
+          toast({
+            title: "Install Failed",
+            description: result.error || "Failed to install package",
+            variant: "destructive",
+          })
+        } else {
+          toast({ title: "Success", description: `Package ${pkg} installed successfully` })
+
+          // Update local state
+          setInstalledRPackages((prev) => [...prev, pkg])
+
+          // Persist to scape.dependencies (like Python)
+          const currentDeps = scape?.dependencies || []
+          if (!currentDeps.includes(pkg)) {
+            const newDeps = [...currentDeps, pkg]
+            setOptimisticDependencies(newDeps)
+            await updateScape({ dependencies: newDeps })
+          }
+        }
+      } catch (err) {
+        console.error("Install failed", err)
+        toast({
+          title: "Install Failed",
+          description: "An unexpected error occurred",
+          variant: "destructive",
+        })
+      }
+    },
+    [toast, scape?.dependencies, updateScape]
+  )
+
   const handleRun = useCallback(() => {
     if (!isRunning) setIsRunning(true)
     handleManualRefresh()
@@ -559,9 +623,25 @@ export default function ScapeEditor() {
 
   const handleDeletePackage = useCallback(
     async (pkg: string) => {
+      // For R, remove from local state AND scape.dependencies
+      if (scape?.environment === "r") {
+        setInstalledRPackages((prev) => prev.filter((p) => p !== pkg))
+
+        // Also remove from scape.dependencies for persistence
+        const currentDeps = scape?.dependencies || []
+        if (currentDeps.includes(pkg)) {
+          const newDeps = currentDeps.filter((d) => d !== pkg)
+          setOptimisticDependencies(newDeps)
+          await updateScape({ dependencies: newDeps })
+        }
+
+        toast({ title: "Removed", description: `${pkg} removed` })
+        return
+      }
+      // For Python, use pip uninstall
       await handleExecCommand("pip-uninstall", pkg)
     },
-    [handleExecCommand]
+    [handleExecCommand, scape?.environment, scape?.dependencies, toast, updateScape]
   )
 
   const handleInputRequest = useCallback(
@@ -1189,8 +1269,14 @@ export default function ScapeEditor() {
                   scape &&
                   ENVIRONMENTS[scape.environment]?.capabilities.packages && (
                     <PackagePane
-                      dependencies={optimisticDependencies ?? (scape?.dependencies || [])}
+                      dependencies={
+                        scape?.environment === "r"
+                          ? installedRPackages
+                          : (optimisticDependencies ?? (scape?.dependencies || []))
+                      }
                       onDeletePackage={handleDeletePackage}
+                      onInstallPackage={(pkg) => handleInstallPackage(pkg, scape?.environment)}
+                      language={scape?.environment}
                     />
                   )}
                 {activeTool === "secrets" && (

--- a/src/runners/r/RRunner.tsx
+++ b/src/runners/r/RRunner.tsx
@@ -13,7 +13,7 @@ import { Loader2, Box, MonitorPlay } from "lucide-react"
 import Worker from "./worker.ts?worker"
 
 export const RRunner = memo(
-  forwardRef<ScapeRunnerHandle, ScapeRunnerProps>(({ files, onOutput }, ref) => {
+  forwardRef<ScapeRunnerHandle, ScapeRunnerProps>(({ files, onOutput, dependencies = [] }, ref) => {
     const workerRef = useRef<Worker | null>(null)
     const containerRef = useRef<HTMLDivElement>(null)
     const [isBusy, setIsBusy] = useState(false)
@@ -48,8 +48,9 @@ export const RRunner = memo(
         const { type, payload } = e.data
 
         if (type === "STATUS") {
-          log("system", payload)
-          console.log("[R Worker]", payload)
+          // User requested silence for system logs
+          // log("system", payload)
+          console.log("[R Worker Status]", payload)
         } else if (type === "OUTPUT") {
           log("stdout", payload)
         } else if (type === "ERROR") {
@@ -68,7 +69,7 @@ export const RRunner = memo(
         setIsBusy(false)
       }
 
-      worker.postMessage({ type: "INIT", payload: {} })
+      worker.postMessage({ type: "INIT", payload: { dependencies } })
 
       return () => {
         worker.terminate()
@@ -139,7 +140,31 @@ export const RRunner = memo(
       restart: async () => {
         runR()
       },
-      installPackage: async () => ({ success: false, error: "Not implemented" }),
+      installPackage: async (pkg: string) => {
+        if (!workerRef.current) return { success: false, error: "Worker not ready" }
+
+        setIsBusy(true)
+
+        return new Promise((resolve) => {
+          const handler = (e: MessageEvent) => {
+            const { type, payload } = e.data
+            if (type === "INSTALL_COMPLETE") {
+              workerRef.current?.removeEventListener("message", handler)
+              setIsBusy(false)
+              if (payload.success) {
+                resolve({ success: true })
+              } else {
+                resolve({ success: false, error: payload.error })
+              }
+            }
+          }
+          workerRef.current?.addEventListener("message", handler)
+          workerRef.current?.postMessage({
+            type: "INSTALL",
+            payload: { pkg },
+          })
+        })
+      },
       runFile: async () => {},
       provideInput: async () => {},
     }))

--- a/src/runners/r/worker.ts
+++ b/src/runners/r/worker.ts
@@ -26,7 +26,7 @@ const loadWebR = async (): Promise<any> => {
 
   loadPromise = (async () => {
     console.log("[R Worker] Starting init...")
-    postMessage({ type: "STATUS", payload: "Loading WebR..." })
+    // postMessage({ type: "STATUS", payload: "Loading WebR..." })
 
     try {
       console.log("[R Worker] Importing WebR from CDN...")
@@ -40,7 +40,7 @@ const loadWebR = async (): Promise<any> => {
       })
       await webr!.init()
 
-      postMessage({ type: "STATUS", payload: "Ready (Automatic)" })
+      // postMessage({ type: "STATUS", payload: "Ready (Automatic)" })
       return webr!
     } catch (e) {
       console.warn("[R Worker] WebR init failed (Automatic), retrying with PostMessage...", e)
@@ -54,7 +54,7 @@ const loadWebR = async (): Promise<any> => {
           channelType: ChannelType.PostMessage,
         })
         await webr!.init()
-        postMessage({ type: "STATUS", payload: "Ready (PostMessage)" })
+        // postMessage({ type: "STATUS", payload: "Ready (PostMessage)" })
         return webr!
       } catch (error: any) {
         console.error("[R Worker] Fatal Error", error)
@@ -76,7 +76,24 @@ self.onmessage = async (e: MessageEvent) => {
   if (type === "INIT") {
     const runInit = async () => {
       try {
-        await loadWebR()
+        const r = await loadWebR()
+
+        // Auto-install dependencies from scape
+        const deps = payload.dependencies || []
+        if (deps.length > 0) {
+          console.log("[R Worker] Auto-installing dependencies:", deps)
+          for (const pkg of deps) {
+            try {
+              console.log(`[R Worker] Installing ${pkg}...`)
+              await r.installPackages([pkg])
+              console.log(`[R Worker] ${pkg} installed`)
+            } catch (e: any) {
+              console.warn(`[R Worker] Failed to install ${pkg}:`, e.message)
+            }
+          }
+          console.log("[R Worker] Dependencies installed")
+        }
+
         postMessage({ type: "DidRun" })
       } catch {
         // Error already reported via postMessage
@@ -84,6 +101,22 @@ self.onmessage = async (e: MessageEvent) => {
     }
     readyPromise = readyPromise.then(runInit)
     await readyPromise
+  }
+  if (type === "INSTALL") {
+    try {
+      console.log("[R Worker] Installing package:", payload.pkg)
+      await readyPromise
+      const r = await loadWebR()
+      await r.installPackages([payload.pkg])
+      console.log("[R Worker] Installation complete")
+      postMessage({ type: "INSTALL_COMPLETE", payload: { success: true } })
+    } catch (e: any) {
+      console.error("[R Worker] Install failed:", e)
+      postMessage({
+        type: "INSTALL_COMPLETE",
+        payload: { success: false, error: e.message },
+      })
+    }
   }
 
   if (type === "RUN") {
@@ -147,24 +180,50 @@ self.onmessage = async (e: MessageEvent) => {
       }
 
       // 3. Run Entry Point
-      postMessage({ type: "STATUS", payload: `Running ${entryPoint}...` })
+      // postMessage({ type: "STATUS", payload: `Running ${entryPoint}...` })
       const mainFile = files.find((f: any) => f.name === entryPoint)
       if (!mainFile) throw new Error(`Entry point ${entryPoint} not found`)
 
       // Simple eval with SVG plot capture wrapper
       const shelter = await new r.Shelter()
       try {
-        // Wrap execution with SVG device setup (more portable than PNG in WebR)
+        // Wrap execution with SVG device setup
+        // Key fix: Capture the LAST expression and print it if it's a ggplot
         const wrappedCode = `
-                    # Setup SVG device to capture plots
-                    svg("__plot_%d.svg", width = 8, height = 6)
-                    tryCatch({
-                        ${mainFile.content}
-                    }, finally = {
-                        # Close all graphics devices
-                        graphics.off()
-                    })
-                `
+          # Clean slate: Remove all user-defined variables from global environment
+          rm(list = ls(all.names = TRUE, envir = .GlobalEnv), envir = .GlobalEnv)
+          
+          # Close any open graphics devices from previous runs
+          graphics.off()
+          
+          # Setup SVG device to capture plots
+          svg("__plot_%d.svg", width = 8, height = 6)
+          
+          # Use tryCatch for safety
+          .codescape_result <- tryCatch({
+            # User code - capture last expression
+            ${mainFile.content}
+          }, error = function(e) {
+            cat("Error:", conditionMessage(e), "\\n", file = stderr())
+            NULL
+          }, warning = function(w) {
+            cat("Warning:", conditionMessage(w), "\\n", file = stderr())
+            invokeRestart("muffleWarning")
+          })
+          
+          # If the result is a ggplot, explicitly print it to render
+          if (!is.null(.codescape_result)) {
+            if (inherits(.codescape_result, "ggplot") || 
+                inherits(.codescape_result, "gg") ||
+                inherits(.codescape_result, "grob") ||
+                inherits(.codescape_result, "gtable")) {
+              print(.codescape_result)
+            }
+          }
+          
+          # Close all graphics devices  
+          graphics.off()
+        `
 
         const result = await shelter.captureR(wrappedCode, {
           withAutoprint: true,
@@ -176,7 +235,22 @@ self.onmessage = async (e: MessageEvent) => {
         result.output.forEach((line: any) => {
           if (line.type === "stdout") postMessage({ type: "OUTPUT", payload: line.data + "\n" })
           if (line.type === "stderr") postMessage({ type: "ERROR", payload: line.data + "\n" })
+          if (line.type === "message") postMessage({ type: "ERROR", payload: line.data + "\n" })
         })
+
+        // Also capture conditions (warnings, messages, errors)
+        if (result.conditions && Array.isArray(result.conditions)) {
+          result.conditions.forEach((cond: any) => {
+            const condMsg = cond.message || cond.data || String(cond)
+            if (cond.type === "error") {
+              postMessage({ type: "ERROR", payload: `Error: ${condMsg}\n` })
+            } else if (cond.type === "warning") {
+              postMessage({ type: "ERROR", payload: `Warning: ${condMsg}\n` })
+            } else if (cond.type === "message") {
+              postMessage({ type: "OUTPUT", payload: condMsg })
+            }
+          })
+        }
       } finally {
         await shelter.purge()
 


### PR DESCRIPTION
- Add R package installation UI in PackagePane (input + install button)
- Implement installPackage in RRunner and worker.ts
- Auto-install dependencies on R worker init
- Clean slate execution (rm(list=ls()) before each run)
- Auto-print ggplot2 objects for preview rendering
- Improve error/warning capture for R output
- Switch Scapper model to qwen/qwen3-32b