### PR TITLE
feat(settings): redesign settings dialog with editor configuration and project management

### DIFF
--- a/src/components/editor/CodeEditor.tsx
+++ b/src/components/editor/CodeEditor.tsx
@@ -3,6 +3,7 @@ import { emmetHTML, emmetCSS } from "emmet-monaco-es"
 import { useTheme } from "@/components/theme-provider"
 import type { Problem } from "@/types/problem"
 import type { ScapeFile } from "@/types/file"
+import type { EditorSettings } from "@/hooks/useEditorSettings"
 import { useEffect, useRef } from "react"
 import { LoadingOverlay } from "@/components/ui/spinner"
 
@@ -14,6 +15,7 @@ interface CodeEditorProps {
   onValidate?: (problems: Problem[]) => void
   files?: ScapeFile[] // All files for IntelliSense
   onRun?: () => void
+  editorSettings?: EditorSettings
 }
 
 // Track global registration of Emmet to prevent duplicates on file switch
@@ -30,6 +32,7 @@ export function CodeEditor({
   onValidate,
   files = [],
   onRun,
+  editorSettings,
 }: CodeEditorProps) {
   const { theme } = useTheme()
   const monaco = useMonaco()
@@ -83,11 +86,12 @@ export function CodeEditor({
     // Store editor reference for external content sync
     editorRef.current = editor
 
-    // Basic configuration
+    // Basic configuration (will be overridden by editorSettings if provided)
     editor.updateOptions({
-      minimap: { enabled: false },
-      fontSize: 14,
-      wordWrap: "on",
+      minimap: { enabled: editorSettings?.minimap ?? false },
+      fontSize: editorSettings?.fontSize ?? 14,
+      wordWrap: editorSettings?.wordWrap ?? "on",
+      lineNumbers: editorSettings?.lineNumbers ?? "on",
       padding: { top: 16 },
       scrollBeyondLastLine: false,
     })
@@ -117,6 +121,18 @@ export function CodeEditor({
       editor.getAction("editor.action.formatDocument")?.run()
     })
   }
+
+  // Apply editor settings dynamically when they change
+  useEffect(() => {
+    if (!editorRef.current || !editorSettings) return
+
+    editorRef.current.updateOptions({
+      fontSize: editorSettings.fontSize,
+      wordWrap: editorSettings.wordWrap,
+      minimap: { enabled: editorSettings.minimap },
+      lineNumbers: editorSettings.lineNumbers,
+    })
+  }, [editorSettings])
 
   // Sync external content changes to Monaco
   // This handles cases like search/replace updating file content

--- a/src/components/editor/SettingsModal.tsx
+++ b/src/components/editor/SettingsModal.tsx
@@ -1,20 +1,44 @@
 import { Dialog, DialogContent, DialogTitle } from "@/components/ui/dialog"
 import { SettingsPane } from "./SettingsPane"
 import { VisuallyHidden } from "@radix-ui/react-visually-hidden"
+import type { EditorSettings } from "@/hooks/useEditorSettings"
+import type { Scape } from "@/lib/db"
 
 interface SettingsModalProps {
   open: boolean
   onOpenChange: (open: boolean) => void
+  editorSettings: EditorSettings
+  onEditorSettingChange: <K extends keyof EditorSettings>(key: K, value: EditorSettings[K]) => void
+  onResetEditorSettings: () => void
+  scape?: Scape
+  onScapeUpdate?: (updates: Partial<Scape>) => Promise<void>
 }
 
-export function SettingsModal({ open, onOpenChange }: SettingsModalProps) {
+export function SettingsModal({
+  open,
+  onOpenChange,
+  editorSettings,
+  onEditorSettingChange,
+  onResetEditorSettings,
+  scape,
+  onScapeUpdate,
+}: SettingsModalProps) {
+  const isCloud = scape?.source === "cloud"
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="flex max-w-2xl flex-col gap-0 overflow-hidden p-0 sm:max-h-[80vh]">
+      <DialogContent className="flex h-[560px] max-w-3xl flex-col gap-0 overflow-hidden p-0">
         <VisuallyHidden>
-          <DialogTitle>Settings</DialogTitle>
+          <DialogTitle>Scape Settings</DialogTitle>
         </VisuallyHidden>
-        <SettingsPane />
+        <SettingsPane
+          editorSettings={editorSettings}
+          onEditorSettingChange={onEditorSettingChange}
+          onResetEditorSettings={onResetEditorSettings}
+          scape={scape}
+          onScapeUpdate={onScapeUpdate}
+          isCloud={isCloud}
+        />
       </DialogContent>
     </Dialog>
   )

--- a/src/components/editor/SettingsPane.tsx
+++ b/src/components/editor/SettingsPane.tsx
@@ -1,74 +1,409 @@
 import { SHORTCUTS, getShortcutLabel, isMac } from "@/config/shortcuts"
-import { Monitor, Keyboard, Laptop, Code2 } from "lucide-react"
+import { Monitor, Keyboard, Laptop, Code2, FolderCog, RotateCcw } from "lucide-react"
+import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs"
+import { Label } from "@/components/ui/label"
+import { Switch } from "@/components/ui/switch"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+import { Separator } from "@/components/ui/separator"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select"
+import type { EditorSettings } from "@/hooks/useEditorSettings"
+import type { Scape } from "@/lib/db"
+import { useState } from "react"
 
-export function SettingsPane() {
+interface SettingsPaneProps {
+  editorSettings: EditorSettings
+  onEditorSettingChange: <K extends keyof EditorSettings>(key: K, value: EditorSettings[K]) => void
+  onResetEditorSettings: () => void
+  scape?: Scape
+  onScapeUpdate?: (updates: Partial<Scape>) => Promise<void>
+  isCloud?: boolean
+}
+
+export function SettingsPane({
+  editorSettings,
+  onEditorSettingChange,
+  onResetEditorSettings,
+  scape,
+  onScapeUpdate,
+  isCloud = false,
+}: SettingsPaneProps) {
+  // Project settings local state
+  const [projectName, setProjectName] = useState(scape?.name || "")
+  const [projectDescription, setProjectDescription] = useState(scape?.description || "")
+  const [isSaving, setIsSaving] = useState(false)
+
+  const handleSaveProject = async () => {
+    if (!onScapeUpdate) return
+    setIsSaving(true)
+    try {
+      await onScapeUpdate({
+        name: projectName,
+        description: projectDescription,
+      })
+    } finally {
+      setIsSaving(false)
+    }
+  }
+
+  const hasProjectChanges =
+    projectName !== scape?.name || projectDescription !== (scape?.description || "")
+
   return (
-    <div className="flex flex-1 flex-col overflow-y-auto bg-background p-6">
-      <div className="mb-8">
-        <h2 className="mb-2 text-2xl font-bold tracking-tight">Editor Settings</h2>
-        <p className="text-muted-foreground">
-          Customize your coding environment and view shortcuts.
+    <div className="flex h-full flex-col bg-background">
+      {/* Header */}
+      <div className="border-b px-6 py-4">
+        <h2 className="text-xl font-semibold tracking-tight">Scape Settings</h2>
+        <p className="text-sm text-muted-foreground">
+          Customize your editor, project, and view shortcuts.
         </p>
       </div>
 
-      <div className="space-y-8">
-        {/* Environment Info */}
-        <section>
-          <div className="mb-4 flex items-center gap-2 border-b pb-2">
-            <Monitor className="h-5 w-5" />
-            <h3 className="text-lg font-semibold">Environment</h3>
-          </div>
-          <div className="grid grid-cols-1 gap-4 text-sm text-muted-foreground sm:grid-cols-2">
-            <div className="rounded-md border p-4">
-              <div className="mb-2 flex items-center gap-2 font-medium text-foreground">
-                <Laptop className="h-4 w-4" />
-                <span>Platform</span>
-              </div>
-              <p>{isMac ? "macOS" : "Windows / Linux"}</p>
-            </div>
-            <div className="rounded-md border p-4">
-              <div className="mb-2 flex items-center gap-2 font-medium text-foreground">
-                <Code2 className="h-4 w-4" />
-                <span>Engine</span>
-              </div>
-              <p>Monaco Editor</p>
-            </div>
-          </div>
-        </section>
+      {/* Tabs Container */}
+      <Tabs defaultValue="editor" className="flex flex-1 overflow-hidden">
+        {/* Left Sidebar - Tab List */}
+        <TabsList className="h-auto w-44 flex-col items-stretch justify-start gap-1 rounded-none border-r bg-muted/30 p-3">
+          <TabsTrigger
+            value="editor"
+            className="justify-start gap-2 px-3 py-2.5 text-left data-[state=active]:bg-background"
+          >
+            <Code2 className="h-4 w-4" />
+            <span>Editor</span>
+          </TabsTrigger>
+          <TabsTrigger
+            value="project"
+            className="justify-start gap-2 px-3 py-2.5 text-left data-[state=active]:bg-background"
+          >
+            <FolderCog className="h-4 w-4" />
+            <span>Project</span>
+          </TabsTrigger>
+          <TabsTrigger
+            value="shortcuts"
+            className="justify-start gap-2 px-3 py-2.5 text-left data-[state=active]:bg-background"
+          >
+            <Keyboard className="h-4 w-4" />
+            <span>Shortcuts</span>
+          </TabsTrigger>
+          <TabsTrigger
+            value="environment"
+            className="justify-start gap-2 px-3 py-2.5 text-left data-[state=active]:bg-background"
+          >
+            <Monitor className="h-4 w-4" />
+            <span>Environment</span>
+          </TabsTrigger>
+        </TabsList>
 
-        {/* Shortcuts Cheat Sheet */}
-        <section>
-          <div className="mb-4 flex items-center gap-2 border-b pb-2">
-            <Keyboard className="h-5 w-5" />
-            <h3 className="text-lg font-semibold">Keyboard Shortcuts</h3>
-          </div>
+        {/* Right Content Area */}
+        <div className="flex-1 overflow-hidden">
+          {/* Editor Tab */}
+          <TabsContent value="editor" className="m-0 h-full overflow-y-auto p-6">
+            <div className="space-y-6">
+              <div>
+                <h3 className="mb-1 text-sm font-medium">Editor Preferences</h3>
+                <p className="text-xs text-muted-foreground">
+                  Customize how code appears in the editor.
+                </p>
+              </div>
 
-          <div className="rounded-lg border bg-card">
-            <div className="grid grid-cols-2 border-b bg-muted/40 p-3 text-sm font-medium">
-              <div>Action</div>
-              <div className="text-right">Keybinding</div>
-            </div>
-            <div className="divide-y">
-              {SHORTCUTS.map((shortcut) => (
-                <div
-                  key={shortcut.id}
-                  className="grid grid-cols-2 items-center p-3 text-sm transition-colors hover:bg-muted/20"
-                >
-                  <div className="flex flex-col gap-0.5">
-                    <span className="font-medium">{shortcut.label}</span>
-                    <span className="text-xs text-muted-foreground">{shortcut.description}</span>
-                  </div>
-                  <div className="flex justify-end">
-                    <kbd className="inline-flex h-6 min-w-[20px] items-center justify-center rounded border bg-muted px-2 font-mono text-[10px] font-medium text-muted-foreground shadow-sm">
-                      {getShortcutLabel(shortcut)}
-                    </kbd>
-                  </div>
+              <Separator />
+
+              {/* Font Size */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label htmlFor="fontSize" className="text-sm font-medium">
+                    Font Size
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Adjust the editor font size (12-24px)
+                  </p>
                 </div>
-              ))}
+                <div className="flex items-center gap-2">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() =>
+                      onEditorSettingChange("fontSize", Math.max(12, editorSettings.fontSize - 1))
+                    }
+                    disabled={editorSettings.fontSize <= 12}
+                  >
+                    -
+                  </Button>
+                  <span className="w-8 text-center text-sm font-medium">
+                    {editorSettings.fontSize}
+                  </span>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    className="h-8 w-8"
+                    onClick={() =>
+                      onEditorSettingChange("fontSize", Math.min(24, editorSettings.fontSize + 1))
+                    }
+                    disabled={editorSettings.fontSize >= 24}
+                  >
+                    +
+                  </Button>
+                </div>
+              </div>
+
+              {/* Word Wrap */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label htmlFor="wordWrap" className="text-sm font-medium">
+                    Word Wrap
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Wrap long lines to fit the editor width
+                  </p>
+                </div>
+                <Select
+                  value={editorSettings.wordWrap}
+                  onValueChange={(value) =>
+                    onEditorSettingChange("wordWrap", value as EditorSettings["wordWrap"])
+                  }
+                >
+                  <SelectTrigger className="w-32">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="on">On</SelectItem>
+                    <SelectItem value="off">Off</SelectItem>
+                    <SelectItem value="wordWrapColumn">Column</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              {/* Minimap */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label htmlFor="minimap" className="text-sm font-medium">
+                    Minimap
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Show a miniature overview of your code
+                  </p>
+                </div>
+                <Switch
+                  id="minimap"
+                  checked={editorSettings.minimap}
+                  onCheckedChange={(checked) => onEditorSettingChange("minimap", checked)}
+                />
+              </div>
+
+              {/* Line Numbers */}
+              <div className="flex items-center justify-between">
+                <div>
+                  <Label htmlFor="lineNumbers" className="text-sm font-medium">
+                    Line Numbers
+                  </Label>
+                  <p className="text-xs text-muted-foreground">
+                    Display line numbers in the gutter
+                  </p>
+                </div>
+                <Select
+                  value={editorSettings.lineNumbers}
+                  onValueChange={(value) =>
+                    onEditorSettingChange("lineNumbers", value as EditorSettings["lineNumbers"])
+                  }
+                >
+                  <SelectTrigger className="w-32">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="on">On</SelectItem>
+                    <SelectItem value="off">Off</SelectItem>
+                    <SelectItem value="relative">Relative</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+
+              <Separator />
+
+              {/* Reset Button */}
+              <div className="flex justify-end">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={onResetEditorSettings}
+                  className="gap-2"
+                >
+                  <RotateCcw className="h-3 w-3" />
+                  Reset to Defaults
+                </Button>
+              </div>
             </div>
-          </div>
-        </section>
-      </div>
+          </TabsContent>
+
+          {/* Project Tab */}
+          <TabsContent value="project" className="m-0 h-full overflow-y-auto p-6">
+            <div className="space-y-6">
+              <div>
+                <h3 className="mb-1 text-sm font-medium">Project Settings</h3>
+                <p className="text-xs text-muted-foreground">
+                  Update your project name and description.
+                </p>
+              </div>
+
+              <Separator />
+
+              {scape ? (
+                <>
+                  {/* Project Name */}
+                  <div className="space-y-2">
+                    <Label htmlFor="projectName">Project Name</Label>
+                    <Input
+                      id="projectName"
+                      value={projectName}
+                      onChange={(e) => setProjectName(e.target.value)}
+                      placeholder="My Awesome Project"
+                      maxLength={100}
+                    />
+                  </div>
+
+                  {/* Description */}
+                  <div className="space-y-2">
+                    <Label htmlFor="projectDescription">Description</Label>
+                    <textarea
+                      id="projectDescription"
+                      value={projectDescription}
+                      onChange={(e) => setProjectDescription(e.target.value)}
+                      placeholder="A brief description of your project..."
+                      maxLength={500}
+                      rows={4}
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                    />
+                    <p className="text-xs text-muted-foreground">
+                      {projectDescription.length}/500 characters
+                    </p>
+                  </div>
+
+                  <Separator />
+
+                  {/* Save Button */}
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs text-muted-foreground">
+                      {isCloud ? "Saved to cloud" : "Saved locally"}
+                    </p>
+                    <Button onClick={handleSaveProject} disabled={!hasProjectChanges || isSaving}>
+                      {isSaving ? "Saving..." : "Save Changes"}
+                    </Button>
+                  </div>
+                </>
+              ) : (
+                <div className="flex flex-col items-center justify-center py-12 text-center">
+                  <FolderCog className="mb-4 h-12 w-12 text-muted-foreground/50" />
+                  <p className="text-sm text-muted-foreground">No project loaded.</p>
+                </div>
+              )}
+            </div>
+          </TabsContent>
+
+          {/* Shortcuts Tab */}
+          <TabsContent value="shortcuts" className="m-0 h-full overflow-y-auto p-6">
+            <div className="space-y-6">
+              <div>
+                <h3 className="mb-1 text-sm font-medium">Keyboard Shortcuts</h3>
+                <p className="text-xs text-muted-foreground">
+                  Quick reference for available shortcuts.
+                </p>
+              </div>
+
+              <div className="rounded-lg border bg-card">
+                <div className="grid grid-cols-2 border-b bg-muted/40 p-3 text-sm font-medium">
+                  <div>Action</div>
+                  <div className="text-right">Keybinding</div>
+                </div>
+                <div className="divide-y">
+                  {SHORTCUTS.map((shortcut) => (
+                    <div
+                      key={shortcut.id}
+                      className="grid grid-cols-2 items-center p-3 text-sm transition-colors hover:bg-muted/20"
+                    >
+                      <div className="flex flex-col gap-0.5">
+                        <span className="font-medium">{shortcut.label}</span>
+                        <span className="text-xs text-muted-foreground">
+                          {shortcut.description}
+                        </span>
+                      </div>
+                      <div className="flex justify-end">
+                        <kbd className="inline-flex h-6 min-w-[20px] items-center justify-center rounded border bg-muted px-2 font-mono text-[10px] font-medium text-muted-foreground shadow-sm">
+                          {getShortcutLabel(shortcut)}
+                        </kbd>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </TabsContent>
+
+          {/* Environment Tab */}
+          <TabsContent value="environment" className="m-0 h-full overflow-y-auto p-6">
+            <div className="space-y-6">
+              <div>
+                <h3 className="mb-1 text-sm font-medium">Environment Information</h3>
+                <p className="text-xs text-muted-foreground">
+                  Details about your coding environment.
+                </p>
+              </div>
+
+              <Separator />
+
+              <div className="grid grid-cols-2 gap-4">
+                {/* Platform */}
+                <div className="rounded-md border p-4">
+                  <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                    <Laptop className="h-4 w-4" />
+                    <span>Platform</span>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    {isMac ? "macOS" : "Windows / Linux"}
+                  </p>
+                </div>
+
+                {/* Engine */}
+                <div className="rounded-md border p-4">
+                  <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                    <Code2 className="h-4 w-4" />
+                    <span>Editor Engine</span>
+                  </div>
+                  <p className="text-sm text-muted-foreground">Monaco Editor</p>
+                </div>
+
+                {/* Environment Type */}
+                {scape && (
+                  <div className="rounded-md border p-4">
+                    <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                      <Monitor className="h-4 w-4" />
+                      <span>Project Type</span>
+                    </div>
+                    <p className="text-sm capitalize text-muted-foreground">{scape.environment}</p>
+                  </div>
+                )}
+
+                {/* Source */}
+                {scape && (
+                  <div className="rounded-md border p-4">
+                    <div className="mb-2 flex items-center gap-2 text-sm font-medium">
+                      <FolderCog className="h-4 w-4" />
+                      <span>Storage</span>
+                    </div>
+                    <p className="text-sm capitalize text-muted-foreground">
+                      {scape.source === "cloud" ? "Cloud Synced" : "Local Only"}
+                    </p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </TabsContent>
+        </div>
+      </Tabs>
     </div>
   )
 }

--- a/src/hooks/useEditorSettings.ts
+++ b/src/hooks/useEditorSettings.ts
@@ -1,0 +1,58 @@
+import { useState, useEffect, useCallback } from "react"
+
+export interface EditorSettings {
+  fontSize: number
+  wordWrap: "on" | "off" | "wordWrapColumn"
+  minimap: boolean
+  lineNumbers: "on" | "off" | "relative"
+}
+
+const DEFAULT_SETTINGS: EditorSettings = {
+  fontSize: 14,
+  wordWrap: "on",
+  minimap: false,
+  lineNumbers: "on",
+}
+
+const STORAGE_KEY = "codescape:editor-settings"
+
+export function useEditorSettings() {
+  const [settings, setSettings] = useState<EditorSettings>(() => {
+    // Initialize from localStorage
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY)
+      if (stored) {
+        return { ...DEFAULT_SETTINGS, ...JSON.parse(stored) }
+      }
+    } catch (e) {
+      console.warn("Failed to parse editor settings from localStorage", e)
+    }
+    return DEFAULT_SETTINGS
+  })
+
+  // Persist to localStorage when settings change
+  useEffect(() => {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(settings))
+    } catch (e) {
+      console.warn("Failed to save editor settings to localStorage", e)
+    }
+  }, [settings])
+
+  const updateSetting = useCallback(
+    <K extends keyof EditorSettings>(key: K, value: EditorSettings[K]) => {
+      setSettings((prev) => ({ ...prev, [key]: value }))
+    },
+    []
+  )
+
+  const resetSettings = useCallback(() => {
+    setSettings(DEFAULT_SETTINGS)
+  }, [])
+
+  return {
+    settings,
+    updateSetting,
+    resetSettings,
+  }
+}

--- a/src/pages/ScapeEditor.tsx
+++ b/src/pages/ScapeEditor.tsx
@@ -50,6 +50,7 @@ import { CodeScapeLogo } from "@/components/brand/Logo"
 import { DeploymentDialog } from "@/components/editor/DeploymentDialog"
 import { debug } from "@/lib/debug"
 import { uploadThumbnail } from "@/lib/services/thumbnailService"
+import { useEditorSettings } from "@/hooks/useEditorSettings"
 
 import {
   AlertDialog,
@@ -224,6 +225,13 @@ export default function ScapeEditor() {
     "codescape:ui:terminalTab",
     "terminal"
   )
+
+  // Editor Settings
+  const {
+    settings: editorSettings,
+    updateSetting: updateEditorSetting,
+    resetSettings: resetEditorSettings,
+  } = useEditorSettings()
 
   // Project Specific State
   const [activeFilePath, setActiveFilePath] = usePersistentState<string | null>(
@@ -1554,6 +1562,7 @@ export default function ScapeEditor() {
                                         onValidate={handleValidate}
                                         files={deferredFiles}
                                         onRun={handleRun}
+                                        editorSettings={editorSettings}
                                       />
                                     )
                                   }
@@ -1789,7 +1798,17 @@ export default function ScapeEditor() {
         </AlertDialogContent>
       </AlertDialog>
 
-      <SettingsModal open={isSettingsOpen} onOpenChange={setIsSettingsOpen} />
+      <SettingsModal
+        open={isSettingsOpen}
+        onOpenChange={setIsSettingsOpen}
+        editorSettings={editorSettings}
+        onEditorSettingChange={updateEditorSetting}
+        onResetEditorSettings={resetEditorSettings}
+        scape={scape}
+        onScapeUpdate={async (updates) => {
+          await updateScape(updates)
+        }}
+      />
     </>
   )
 }


### PR DESCRIPTION
- Added `useEditorSettings` hook for persistent editor configuration
- Redesigned `SettingsPane` with tabbed navigation (Editor, Project, Shortcuts, Environment)
- Added controls for Font Size, Word Wrap, Minimap, and Line Numbers
- Enabled project name and description editing for both local and cloud scapes
- Updated `CodeEditor` to reactively apply settings to Monaco