### PR TITLE
fix(sandbox): silence console logs in production environment

### DIFF
--- a/public/sandbox/bootloader.html
+++ b/public/sandbox/bootloader.html
@@ -49,6 +49,9 @@
 
       const PARENT_ORIGIN = "*"
 
+      // DEBUG: Automatically disabled on production (non-localhost)
+      const DEBUG = location.hostname === "localhost" || location.hostname === "127.0.0.1"
+
       const nativeConsole = {
         log: console.log.bind(console),
         warn: console.warn.bind(console),
@@ -56,9 +59,9 @@
       }
 
       const sys = {
-        log: (...args) => nativeConsole.log(...args),
-        warn: (...args) => nativeConsole.warn(...args),
-        error: (...args) => nativeConsole.error(...args)
+        log: (...args) => DEBUG && nativeConsole.log(...args),
+        warn: (...args) => DEBUG && nativeConsole.warn(...args),
+        error: (...args) => nativeConsole.error(...args)  // Errors always logged
       }
 
       // Proxy User Console to Parent

--- a/public/sandbox/receiver.js
+++ b/public/sandbox/receiver.js
@@ -8,8 +8,8 @@
  * 5. Redirects to /run/<id>/index.html
  */
 
-// DEBUG: Set to false for production builds (Vercel)
-const DEBUG = true
+// DEBUG: Automatically disabled on production (non-localhost)
+const DEBUG = location.hostname === "localhost" || location.hostname === "127.0.0.1"
 const log = (...args) => DEBUG && console.log(...args)
 
 const PARENT_ORIGIN = "*" // Should be strict in production

--- a/public/sandbox/sw.js
+++ b/public/sandbox/sw.js
@@ -1,7 +1,7 @@
 /// <reference lib="webworker" />
 
-// DEBUG: Set to false for production builds (Vercel)
-const DEBUG = true
+// DEBUG: Automatically disabled on production (non-localhost)
+const DEBUG = self.location.hostname === "localhost" || self.location.hostname === "127.0.0.1"
 const log = (...args) => DEBUG && console.log(...args)
 const warn = (...args) => DEBUG && console.warn(...args)
 
@@ -83,7 +83,6 @@ self.addEventListener("message", async (event) => {
           window.addEventListener("unhandledrejection", function(e) {
              window.parent.postMessage({ type: "SANDBOX_LOG", level: "error", payload: ["Unhandled Rejection:", e.reason] }, PARENT_ORIGIN);
           });
-          nativeConsole.log("[Sandbox Preamble] Setting process.env", ${JSON.stringify(Object.keys(envSafe))});
           var env = ${JSON.stringify(envSafe)};
           window.process = window.process || {};
           window.process.env = env;
@@ -297,7 +296,10 @@ self.addEventListener("message", async (event) => {
           // Construct Cache Key using environment-aware prefix
           // Note: file.name might contain subdirectories e.g. "css/style.css"
           // We must ensure it matches the fetch request URL exactly.
-          const cacheUrl = new URL(`${RUN_PATH_PREFIX}/${scapeId}/${file.name}`, self.location.origin)
+          const cacheUrl = new URL(
+            `${RUN_PATH_PREFIX}/${scapeId}/${file.name}`,
+            self.location.origin
+          )
 
           await cache.put(
             cacheUrl,


### PR DESCRIPTION
Problem: Sandbox bootloader, service worker, and receiver were logging debug information in production, exposing implementation details.

Solution: Replaced hardcoded DEBUG = true with runtime detection of localhost. Logs are now completely suppressed on production domains (sandbox.codescapes.io), but remain active during local development.

Changes:
- sw.js: Added hostname check for DEBUG
- receiver.js: Added hostname check for DEBUG
- bootloader.html: Added hostname check for DEBUG and conditioned sys.log/warn
- sw.js: Removed unconditional preamble log message