### PR TITLE
feat(ui): implement caching and infinite scroll for Community page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "@sentry/react": "^10.30.0",
         "@supabase/supabase-js": "^2.88.0",
         "@tailwindcss/typography": "^0.5.19",
+        "@tanstack/react-query": "^5.90.16",
         "@types/uuid": "^10.0.0",
         "blockly": "^12.3.1",
         "clsx": "^2.1.1",
@@ -4841,6 +4842,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.16",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.16.tgz",
+      "integrity": "sha512-MvtWckSVufs/ja463/K4PyJeqT+HMlJWtw6PrCpywznd2NSgO3m4KwO9RqbFqGg6iDE8vVMFWMeQI4Io3eEYww==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.16",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.16.tgz",
+      "integrity": "sha512-bpMGOmV4OPmif7TNMteU/Ehf/hoC0Kf98PDc0F4BZkFrEapRMEqI/V6YS0lyzwSV6PQpY1y4xxArUIfBW5LVxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@sentry/react": "^10.30.0",
     "@supabase/supabase-js": "^2.88.0",
     "@tailwindcss/typography": "^0.5.19",
+    "@tanstack/react-query": "^5.90.16",
     "@types/uuid": "^10.0.0",
     "blockly": "^12.3.1",
     "clsx": "^2.1.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,55 +19,58 @@ import { AdminLayout } from "@/layouts/AdminLayout"
 import { AdminDashboard } from "@/pages/admin/AdminDashboard"
 import { AdminEditor } from "@/pages/admin/AdminEditor"
 import { AdminOverview } from "@/pages/admin/AdminOverview"
+import { QueryProvider } from "@/providers/QueryProvider"
 
 function App() {
   return (
     <ThemeProvider defaultTheme="dark" storageKey="vite-ui-theme">
-      <ErrorBoundary>
-        <BrowserRouter>
-          <Routes>
-            <Route path="/login" element={<AuthPage />} />
-            <Route path="/" element={<Navigate to="/dashboard" replace />} />
-            <Route path="/dashboard" element={<Navigate to="/dashboard/scapes" replace />} />
-            <Route path="/dashboard/:tab" element={<Dashboard />} />
-            <Route path="/scape/:scapeId" element={<ScapeEditor />} />
-            <Route path="/flow/:scapeId" element={<FlowEditor />} />
-            <Route path="/auth/callback" element={<AuthCallback />} />
+      <QueryProvider>
+        <ErrorBoundary>
+          <BrowserRouter>
+            <Routes>
+              <Route path="/login" element={<AuthPage />} />
+              <Route path="/" element={<Navigate to="/dashboard" replace />} />
+              <Route path="/dashboard" element={<Navigate to="/dashboard/scapes" replace />} />
+              <Route path="/dashboard/:tab" element={<Dashboard />} />
+              <Route path="/scape/:scapeId" element={<ScapeEditor />} />
+              <Route path="/flow/:scapeId" element={<FlowEditor />} />
+              <Route path="/auth/callback" element={<AuthCallback />} />
 
-            {/* Run Routes */}
-            {/* /run: Dev Mode (with console) */}
-            <Route path="/run/:scapeId" element={<ScapeRunnerPage mode="dev" />} />
-            {/* /live: Draft Preview (no console) - "Secret Developer Preview" */}
-            <Route path="/live/:scapeId" element={<ScapeRunnerPage mode="live" />} />
-            {/* /view: Public Deployment (Frozen Snapshot) - Community Link */}
-            <Route path="/view/:scapeId" element={<ScapeRunnerPage mode="published" />} />
+              {/* Run Routes */}
+              {/* /run: Dev Mode (with console) */}
+              <Route path="/run/:scapeId" element={<ScapeRunnerPage mode="dev" />} />
+              {/* /live: Draft Preview (no console) - "Secret Developer Preview" */}
+              <Route path="/live/:scapeId" element={<ScapeRunnerPage mode="live" />} />
+              {/* /view: Public Deployment (Frozen Snapshot) - Community Link */}
+              <Route path="/view/:scapeId" element={<ScapeRunnerPage mode="published" />} />
 
-            {/* Community Routes */}
-            <Route path="/community" element={<CommunityPage />} />
-            <Route path="/community/scape/:scapeId" element={<ScapeDetailPage />} />
+              {/* Community Routes */}
+              <Route path="/community" element={<CommunityPage />} />
+              <Route path="/community/scape/:scapeId" element={<ScapeDetailPage />} />
 
-            {/* Docs Routes */}
-            <Route path="/docs" element={<Navigate to="/docs/introduction" replace />} />
-            <Route
-              path="/docs/:slug"
-              element={
-                <DocsLayout>
-                  <DocsPage />
-                </DocsLayout>
-              }
-            />
+              {/* Docs Routes */}
+              <Route path="/docs" element={<Navigate to="/docs/introduction" replace />} />
+              <Route
+                path="/docs/:slug"
+                element={
+                  <DocsLayout>
+                    <DocsPage />
+                  </DocsLayout>
+                }
+              />
 
-            {/* Admin Routes */}
-            <Route path="/admin" element={<AdminLayout />}>
-              <Route index element={<AdminOverview />} />
-              <Route path="docs" element={<AdminDashboard />} />
-              <Route path="docs/new" element={<AdminEditor />} />
-              <Route path="docs/edit/:id" element={<AdminEditor />} />
-            </Route>
-          </Routes>
-        </BrowserRouter>
-      </ErrorBoundary>
-      <Toaster />
+              {/* Admin Routes */}
+              <Route path="/admin" element={<AdminLayout />}>
+                <Route index element={<AdminOverview />} />
+                <Route path="docs" element={<AdminDashboard />} />
+                <Route path="docs/new" element={<AdminEditor />} />
+                <Route path="docs/edit/:id" element={<AdminEditor />} />
+              </Route>
+            </Routes>
+          </BrowserRouter>
+        </ErrorBoundary>
+        <Toaster />
+      </QueryProvider>
     </ThemeProvider>
   )
 }

--- a/src/hooks/useCommunityScapes.ts
+++ b/src/hooks/useCommunityScapes.ts
@@ -1,0 +1,48 @@
+import { useInfiniteQuery } from "@tanstack/react-query"
+import { CloudRepository } from "@/lib/repositories/CloudRepository"
+import { type Scape } from "@/lib/db"
+
+const repo = new CloudRepository()
+
+type FilterType = "all" | "web" | "python" | "flow"
+
+interface UseCommunityScapesOptions {
+  filter?: FilterType
+  enabled?: boolean
+}
+
+export function useCommunityScapes({
+  filter = "all",
+  enabled = true,
+}: UseCommunityScapesOptions = {}) {
+  const filterValue = filter === "all" ? undefined : filter
+
+  const query = useInfiniteQuery({
+    queryKey: ["communityScapes", filter],
+    queryFn: async ({ pageParam = 0 }) => {
+      return repo.getPublicScapesPaginated(filterValue, pageParam, 24)
+    },
+    getNextPageParam: (lastPage, allPages) => {
+      if (!lastPage.hasMore) return undefined
+      return allPages.length // Next page number
+    },
+    initialPageParam: 0,
+    staleTime: 2 * 60 * 1000, // 2 minutes
+    gcTime: 10 * 60 * 1000, // 10 minutes cache
+    enabled,
+  })
+
+  // Flatten all pages into a single array of scapes
+  const scapes: Scape[] = query.data?.pages.flatMap((page) => page.data) || []
+
+  return {
+    scapes,
+    isLoading: query.isLoading,
+    isFetching: query.isFetching,
+    isFetchingNextPage: query.isFetchingNextPage,
+    hasNextPage: query.hasNextPage,
+    fetchNextPage: query.fetchNextPage,
+    error: query.error,
+    refetch: query.refetch,
+  }
+}

--- a/src/hooks/useScapes.ts
+++ b/src/hooks/useScapes.ts
@@ -1,5 +1,6 @@
-import { useState, useEffect, useMemo } from "react"
+import { useMemo, useCallback } from "react"
 import { useLiveQuery } from "dexie-react-hooks"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { type Scape } from "@/lib/db"
 import { LocalRepository } from "@/lib/repositories/LocalRepository"
 import { CloudRepository } from "@/lib/repositories/CloudRepository"
@@ -10,40 +11,25 @@ const cloudRepo = new CloudRepository()
 
 export function useScapes() {
   const { user, loading: authLoading } = useAuth()
-  const [cloudScapes, setCloudScapes] = useState<Scape[]>([])
-  const [loadingCloud, setLoadingCloud] = useState(false)
+  const queryClient = useQueryClient()
 
   // Derived ID for stable dependency (prevent refetch on object reference change)
   const userId = user?.id
 
-  // 1. Local Scapes (Live)
+  // 1. Local Scapes (Live from Dexie)
   const localScapes = useLiveQuery(() => localRepo.listScapes(), [])
 
-  // 2. Cloud Scapes (Effect)
-  useEffect(() => {
-    if (!userId) {
-      setCloudScapes([])
-      return
-    }
-
-    let isMounted = true
-    const fetchCloud = async () => {
-      setLoadingCloud(true)
-      try {
-        const scapes = await cloudRepo.listScapes(userId)
-        if (isMounted) setCloudScapes(scapes)
-      } catch (e) {
-        console.error("Failed to fetch cloud scapes", e)
-      } finally {
-        if (isMounted) setLoadingCloud(false)
-      }
-    }
-
-    fetchCloud()
-    return () => {
-      isMounted = false
-    }
-  }, [userId])
+  // 2. Cloud Scapes (React Query with SWR caching)
+  const { data: cloudScapes = [], isLoading: loadingCloud } = useQuery({
+    queryKey: ["cloudScapes", userId],
+    queryFn: async () => {
+      if (!userId) return []
+      return cloudRepo.listScapes(userId)
+    },
+    enabled: !!userId,
+    staleTime: 1 * 60 * 1000, // 1 minute - data considered fresh
+    gcTime: 5 * 60 * 1000, // 5 minutes cache
+  })
 
   // 3. Merge & Sort (Deduplicate)
   const combinedScapes = useMemo(() => {
@@ -74,23 +60,26 @@ export function useScapes() {
     )
   }, [localScapes, cloudScapes, user])
 
-  const deleteScape = async (scape: Scape) => {
-    try {
-      if (scape.source === "cloud") {
-        await cloudRepo.deleteScape(scape.id)
-        // Also delete from local (offline cache) to prevent ghosts
-        await localRepo.deleteScape(scape.id)
+  const deleteScape = useCallback(
+    async (scape: Scape) => {
+      try {
+        if (scape.source === "cloud") {
+          await cloudRepo.deleteScape(scape.id)
+          // Also delete from local (offline cache) to prevent ghosts
+          await localRepo.deleteScape(scape.id)
 
-        // Optimistic update
-        setCloudScapes((prev) => prev.filter((s) => s.id !== scape.id))
-      } else {
-        await localRepo.deleteScape(scape.id)
+          // Invalidate cache to refetch
+          queryClient.invalidateQueries({ queryKey: ["cloudScapes"] })
+        } else {
+          await localRepo.deleteScape(scape.id)
+        }
+      } catch (e) {
+        console.error("Failed to delete scape", e)
+        throw e
       }
-    } catch (e) {
-      console.error("Failed to delete scape", e)
-      throw e
-    }
-  }
+    },
+    [queryClient]
+  )
 
   return {
     scapes: combinedScapes,

--- a/src/lib/repositories/CloudRepository.ts
+++ b/src/lib/repositories/CloudRepository.ts
@@ -527,6 +527,102 @@ export class CloudRepository implements IScapeRepository {
     })
   }
 
+  /**
+   * Paginated version of getPublicScapes for infinite scroll.
+   * Returns scapes with pagination info.
+   */
+  async getPublicScapesPaginated(
+    filter?: "web" | "python" | "flow",
+    page: number = 0,
+    limit: number = 24
+  ): Promise<{ data: Scape[]; hasMore: boolean }> {
+    const from = page * limit
+    const to = from + limit - 1
+
+    let query = supabase
+      .from("scapes")
+      .select(
+        `
+        id,
+        name,
+        environment,
+        template,
+        thumbnail,
+        description,
+        parent_id,
+        author_id,
+        created_at,
+        updated_at,
+        is_public,
+        published_version_id,
+        dependencies,
+        profiles (
+          full_name,
+          username,
+          avatar_url
+        ),
+        deployments!published_version_id (
+          thumbnail
+        ),
+        likes (count),
+        comments (count)
+      `,
+        { count: "exact" }
+      )
+      .eq("is_public", true)
+      .not("published_version_id", "is", null)
+      .order("updated_at", { ascending: false })
+      .range(from, to)
+
+    if (filter) {
+      query = query.eq("environment", filter)
+    }
+
+    const { data, error, count } = await query
+    if (error) throw error
+
+    const totalCount = count || 0
+    const hasMore = from + (data?.length || 0) < totalCount
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const scapes = (data || []).map((d: any) => {
+      const deploymentRaw = d.deployments
+      const deployment = Array.isArray(deploymentRaw) ? deploymentRaw[0] : deploymentRaw
+      const frozenThumbnail = deployment?.thumbnail
+
+      return {
+        id: d.id,
+        name: d.name,
+        environment: d.environment as Scape["environment"],
+        template: d.template,
+        source: "cloud" as const,
+        authorId: d.author_id,
+        syncStatus: "synced" as const,
+        createdAt: new Date(d.created_at),
+        updatedAt: new Date(d.updated_at),
+        thumbnail: frozenThumbnail || d.thumbnail,
+        dependencies: d.dependencies || [],
+        is_public: true,
+        description: d.description,
+        parentId: d.parent_id,
+        author: d.profiles
+          ? {
+              name: d.profiles.full_name || d.profiles.username || "Unknown",
+              avatar: d.profiles.avatar_url,
+              username: d.profiles.username,
+            }
+          : undefined,
+        stats: {
+          views: 0,
+          likes: d.likes?.[0]?.count || 0,
+          forks: 0,
+        },
+      }
+    })
+
+    return { data: scapes, hasMore }
+  }
+
   async toggleLike(scapeId: string, userId: string): Promise<boolean> {
     // Check if liked
     const { data: existing } = await supabase

--- a/src/pages/Community.tsx
+++ b/src/pages/Community.tsx
@@ -1,21 +1,17 @@
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef, useCallback, useMemo } from "react"
 import { useNavigate, useLocation, useSearchParams } from "react-router-dom"
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
-import { Menu, Search, Heart, GitFork, User, Code2 } from "lucide-react"
-
-import { Input } from "@/components/ui/input"
-import { Button } from "@/components/ui/button"
-import { Card, CardContent, CardFooter, CardHeader, CardTitle } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
-import { Skeleton } from "@/components/ui/skeleton"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from "@/components/ui/card"
+import { Search, Heart, GitFork, User, Code2, Menu, Loader2 } from "lucide-react"
 import { Sidebar } from "@/components/layout/Sidebar"
 import { Header } from "@/components/layout/Header"
 
 import { optimizeSupabaseImage } from "@/lib/utils"
-import { CloudRepository } from "@/lib/repositories/CloudRepository"
-import { type Scape } from "@/lib/db"
-
-const repo = new CloudRepository()
+import { Skeleton } from "@/components/ui/skeleton"
+import { useCommunityScapes } from "@/hooks/useCommunityScapes"
 
 type FilterType = "all" | "web" | "python" | "flow"
 
@@ -24,51 +20,61 @@ export default function CommunityPage() {
   const location = useLocation()
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const [scapes, setScapes] = useState<Scape[]>([])
-  const [loading, setLoading] = useState(true)
   const [searchQuery, setSearchQuery] = useState("")
 
   // Get filter from URL or default to "all"
   const filterFromUrl = (searchParams.get("filter") as FilterType) || "all"
   const [filter, setFilter] = useState<FilterType>(filterFromUrl)
 
-  // Browser Detection
-  const [isRestrictedBrowser, setIsRestrictedBrowser] = useState(false)
-
-  useEffect(() => {
-    if (typeof navigator !== "undefined") {
-      const isIOS =
-        /iPad|iPhone|iPod/.test(navigator.userAgent) ||
-        (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
-      const isSafariRaw =
-        /Safari/.test(navigator.userAgent) &&
-        !/Chrome/.test(navigator.userAgent) &&
-        !/Chromium/.test(navigator.userAgent)
-
-      if (isIOS || isSafariRaw) {
-        setIsRestrictedBrowser(true)
-        setFilter("python")
-      }
-    }
+  // Browser Detection (computed once on mount)
+  const isRestrictedBrowser = useMemo(() => {
+    if (typeof navigator === "undefined") return false
+    const isIOS =
+      /iPad|iPhone|iPod/.test(navigator.userAgent) ||
+      (navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+    const isSafariRaw =
+      /Safari/.test(navigator.userAgent) &&
+      !/Chrome/.test(navigator.userAgent) &&
+      !/Chromium/.test(navigator.userAgent)
+    return isIOS || isSafariRaw
   }, [])
 
-  useEffect(() => {
-    async function load() {
-      setLoading(true)
-      try {
-        const data = await repo.getPublicScapes(filter === "all" ? undefined : filter)
-        setScapes(data)
-      } catch (e) {
-        console.error("Failed to load community scapes", e)
-      } finally {
-        setLoading(false)
-      }
-    }
-    // Dont reload if we are just setting the restricted filter initially to avoid double fetch if possible,
-    // but here simplicity is fine.
-    load()
-  }, [filter])
+  // Effective filter (force python for restricted browsers)
+  const effectiveFilter = isRestrictedBrowser ? "python" : filter
 
+  // Use the cached infinite query hook
+  const { scapes, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useCommunityScapes({
+    filter: effectiveFilter,
+  })
+
+  // Intersection Observer for infinite scroll
+  const loadMoreRef = useRef<HTMLDivElement>(null)
+
+  const handleObserver = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const [entry] = entries
+      if (entry.isIntersecting && hasNextPage && !isFetchingNextPage) {
+        fetchNextPage()
+      }
+    },
+    [hasNextPage, isFetchingNextPage, fetchNextPage]
+  )
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleObserver, {
+      root: null,
+      rootMargin: "200px", // Trigger 200px before reaching bottom
+      threshold: 0,
+    })
+
+    if (loadMoreRef.current) {
+      observer.observe(loadMoreRef.current)
+    }
+
+    return () => observer.disconnect()
+  }, [handleObserver])
+
+  // Client-side search filter
   const filteredScapes = scapes.filter((s) => {
     const matchesSearch = s.name.toLowerCase().includes(searchQuery.toLowerCase())
     // Hard filter for restricted browsers (Safari/iOS)
@@ -196,9 +202,9 @@ export default function CommunityPage() {
             </div>
 
             {/* Grid */}
-            {loading ? (
+            {isLoading ? (
               <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10].map((i) => (
+                {[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12].map((i) => (
                   <Skeleton key={i} className="h-52 w-full rounded-xl" />
                 ))}
               </div>
@@ -209,75 +215,99 @@ export default function CommunityPage() {
                 <p className="text-muted-foreground">Try creating one or adjust your filters.</p>
               </div>
             ) : (
-              <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-                {filteredScapes.map((scape) => (
-                  <Card
-                    key={scape.id}
-                    className="group cursor-pointer overflow-hidden transition-all hover:border-primary/50 hover:shadow-lg"
-                    onClick={() =>
-                      navigate(`/community/scape/${scape.id}`, {
-                        state: { from: location.pathname },
-                      })
-                    }
-                  >
-                    {/* Thumbnail */}
-                    <div className="relative aspect-video bg-muted">
-                      {scape.thumbnail ? (
-                        <img
-                          src={optimizeSupabaseImage(scape.thumbnail, 600)}
-                          alt={scape.name}
-                          className="h-full w-full object-cover"
-                        />
-                      ) : (
-                        <div className="flex h-full items-center justify-center bg-secondary/20">
-                          {getIcon(scape.environment)}
-                        </div>
-                      )}
-                      <div className="absolute inset-0 bg-black/0 transition-all group-hover:bg-black/10" />
-                    </div>
-
-                    <CardHeader className="p-3 pb-1.5">
-                      <div className="flex items-start justify-between gap-2">
-                        <CardTitle className="line-clamp-1 text-sm font-medium leading-none">
-                          {scape.name}
-                        </CardTitle>
-                        <Badge variant="outline" className="h-5 px-1 text-[10px]">
-                          {getEnvLabel(scape.environment)}
-                        </Badge>
-                      </div>
-                    </CardHeader>
-                    <CardContent className="p-3 pt-0">
-                      <p className="line-clamp-2 text-xs text-muted-foreground">
-                        {scape.description || "No description provided."}
-                      </p>
-                    </CardContent>
-                    <CardFooter className="flex items-center justify-between border-t p-3 text-[10px] text-muted-foreground">
-                      <div className="flex items-center gap-1.5 overflow-hidden">
-                        {scape.author?.avatar ? (
+              <>
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                  {filteredScapes.map((scape) => (
+                    <Card
+                      key={scape.id}
+                      className="group cursor-pointer overflow-hidden transition-all hover:border-primary/50 hover:shadow-lg"
+                      onClick={() =>
+                        navigate(`/community/scape/${scape.id}`, {
+                          state: { from: location.pathname },
+                        })
+                      }
+                    >
+                      {/* Thumbnail */}
+                      <div className="relative aspect-video bg-muted">
+                        {scape.thumbnail ? (
                           <img
-                            src={optimizeSupabaseImage(scape.author.avatar, 64, 64)}
-                            alt="Author"
-                            className="h-3.5 w-3.5 rounded-full"
+                            src={optimizeSupabaseImage(scape.thumbnail, 600)}
+                            alt={scape.name}
+                            className="h-full w-full object-cover"
                           />
                         ) : (
-                          <User className="h-3 w-3" />
+                          <div className="flex h-full items-center justify-center bg-secondary/20">
+                            {getIcon(scape.environment)}
+                          </div>
                         )}
-                        <span className="truncate">{scape.author?.name || "Unknown"}</span>
+                        <div className="absolute inset-0 bg-black/0 transition-all group-hover:bg-black/10" />
                       </div>
-                      <div className="flex shrink-0 items-center gap-2">
-                        <div className="flex items-center gap-1">
-                          <Heart className="h-3 w-3" />
-                          <span>{scape.stats?.likes || 0}</span>
+
+                      <CardHeader className="p-3 pb-1.5">
+                        <div className="flex items-start justify-between gap-2">
+                          <CardTitle className="line-clamp-1 text-sm font-medium leading-none">
+                            {scape.name}
+                          </CardTitle>
+                          <Badge variant="outline" className="h-5 px-1 text-[10px]">
+                            {getEnvLabel(scape.environment)}
+                          </Badge>
                         </div>
-                        <div className="flex items-center gap-1">
-                          <GitFork className="h-3 w-3" />
-                          <span>{scape.stats?.forks || 0}</span>
+                      </CardHeader>
+                      <CardContent className="p-3 pt-0">
+                        <p className="line-clamp-2 text-xs text-muted-foreground">
+                          {scape.description || "No description provided."}
+                        </p>
+                      </CardContent>
+                      <CardFooter className="flex items-center justify-between border-t p-3 text-[10px] text-muted-foreground">
+                        <div className="flex items-center gap-1.5 overflow-hidden">
+                          {scape.author?.avatar ? (
+                            <img
+                              src={optimizeSupabaseImage(scape.author.avatar, 64, 64)}
+                              alt="Author"
+                              className="h-3.5 w-3.5 rounded-full"
+                            />
+                          ) : (
+                            <User className="h-3 w-3" />
+                          )}
+                          <span className="truncate">{scape.author?.name || "Unknown"}</span>
                         </div>
-                      </div>
-                    </CardFooter>
-                  </Card>
-                ))}
-              </div>
+                        <div className="flex shrink-0 items-center gap-2">
+                          <div className="flex items-center gap-1">
+                            <Heart className="h-3 w-3" />
+                            <span>{scape.stats?.likes || 0}</span>
+                          </div>
+                          <div className="flex items-center gap-1">
+                            <GitFork className="h-3 w-3" />
+                            <span>{scape.stats?.forks || 0}</span>
+                          </div>
+                        </div>
+                      </CardFooter>
+                    </Card>
+                  ))}
+                </div>
+
+                {/* Infinite Scroll Trigger */}
+                <div ref={loadMoreRef} className="mt-8 flex justify-center">
+                  {isFetchingNextPage && (
+                    <div className="flex items-center gap-2 text-muted-foreground">
+                      <Loader2 className="h-5 w-5 animate-spin" />
+                      <span>Loading more...</span>
+                    </div>
+                  )}
+                  {!hasNextPage && scapes.length > 0 && (
+                    <p className="text-sm text-muted-foreground">You've reached the end</p>
+                  )}
+                </div>
+
+                {/* Skeleton placeholders while loading more */}
+                {isFetchingNextPage && (
+                  <div className="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+                    {[1, 2, 3, 4, 5, 6].map((i) => (
+                      <Skeleton key={`loading-${i}`} className="h-52 w-full rounded-xl" />
+                    ))}
+                  </div>
+                )}
+              </>
             )}
           </main>
         </div>

--- a/src/providers/QueryProvider.tsx
+++ b/src/providers/QueryProvider.tsx
@@ -1,0 +1,22 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { type ReactNode } from "react"
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // Stale-while-revalidate: Show cached data immediately, refetch in background
+      staleTime: 2 * 60 * 1000, // 2 minutes - data considered fresh
+      gcTime: 10 * 60 * 1000, // 10 minutes - keep in cache (formerly cacheTime)
+      refetchOnWindowFocus: false, // Don't refetch on tab focus
+      retry: 1, // Only retry once on failure
+    },
+  },
+})
+
+interface QueryProviderProps {
+  children: ReactNode
+}
+
+export function QueryProvider({ children }: QueryProviderProps) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+}


### PR DESCRIPTION
Major performance improvements:

1. React Query Integration
   - Added @tanstack/react-query for SWR caching
   - Created QueryProvider with sensible defaults (2min stale, 10min cache)
   - Wrapped App in QueryProvider

2. Community Page - Infinite Scroll
   - Load 24 items per page
   - Intersection Observer triggers loading more on scroll
   - Skeleton placeholders while loading more
   - Added getPublicScapesPaginated API method
   - Created useCommunityScapes hook with useInfiniteQuery

3. Dashboard - Caching
   - Updated useScapes to use React Query for cloud scapes
   - Cached data shows instantly, refetches in background
   - 1 minute stale time for dashboard

Result: Pages load instantly on revisit, scrolling loads more items with visual feedback, no full-page loading spinners on navigation.