### PR TITLE
feat(tour): guided tour system with persistence and restart

### DIFF
--- a/src/components/layout/EditorActivityBar.tsx
+++ b/src/components/layout/EditorActivityBar.tsx
@@ -1,4 +1,4 @@
-import { Files, Search, Settings, Lock, MessageSquarePlus } from "lucide-react"
+import { Files, Search, Settings, Lock, MessageSquarePlus, HelpCircle } from "lucide-react"
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"
 import { FeedbackDialog } from "@/components/feedback/FeedbackDialog"
@@ -14,6 +14,7 @@ interface EditorActivityBarProps {
   activeTool: string | null
   onToolSelect: (toolId: string | null) => void
   onSettingsClick: () => void
+  onHelpClick?: () => void
   className?: string
   topTools?: ActivityTool[]
   bottomTools?: ActivityTool[]
@@ -23,6 +24,7 @@ export function EditorActivityBar({
   activeTool,
   onToolSelect,
   onSettingsClick,
+  onHelpClick,
   className,
   topTools = [],
   bottomTools = [],
@@ -55,6 +57,7 @@ export function EditorActivityBar({
         {toolsToRender.map((tool) => (
           <Button
             key={tool.id}
+            data-tour={`sidebar-${tool.id}`}
             variant={activeTool === tool.id ? "secondary" : "ghost"}
             size="icon"
             onClick={() => handleToolClick(tool.id)}
@@ -103,6 +106,18 @@ export function EditorActivityBar({
             </Button>
           }
         />
+
+        {onHelpClick && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-10 w-10 text-muted-foreground"
+            title="Help / Restart Tour"
+            onClick={onHelpClick}
+          >
+            <HelpCircle className="h-5 w-5" />
+          </Button>
+        )}
 
         <Button
           variant="ghost"

--- a/src/components/tour/TourAutoStart.tsx
+++ b/src/components/tour/TourAutoStart.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { useTour } from "./TourProvider"
+import { getTourForEnvironment } from "@/lib/tours"
+import { TourWelcomeModal } from "./TourWelcomeModal"
+
+interface TourAutoStartProps {
+    /** Environment type to determine which tour to show */
+    environment: string
+    /** Display name for the environment */
+    environmentName?: string
+}
+
+// Module-level tracking to survive component remounts within same session
+let hasShownModal = false
+
+/**
+ * TourAutoStart - Shows welcome modal asking if user wants a guided tour
+ * Must be placed inside TourProvider
+ * 
+ * Note: Skipping or closing the modal marks the tour as dismissed
+ * so it won't show again automatically. Users can restart via sidebar.
+ */
+export function TourAutoStart({ environment, environmentName }: TourAutoStartProps) {
+    const { startTour, hasCompletedTour, isActive, markTourDismissed } = useTour()
+    const [showWelcome, setShowWelcome] = useState(false)
+    const [tourId, setTourId] = useState<string | null>(null)
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Showing modal based on tour availability check is a valid derived state pattern
+    useEffect(() => {
+        // If already shown modal in this session or tour active, skip
+        if (hasShownModal || isActive) return
+
+        // Get tour for this environment
+        const tour = getTourForEnvironment(environment)
+        if (!tour) return
+
+        // Check if already completed/dismissed (persisted in localStorage/profile)
+        if (hasCompletedTour(tour.id)) return
+
+        // Check if showOnFirstVisit is enabled
+        if (!tour.showOnFirstVisit) return
+
+        // Show welcome modal
+        hasShownModal = true
+        setTourId(tour.id)
+        setShowWelcome(true)
+    }, [environment, hasCompletedTour, isActive])
+
+    const handleStart = () => {
+        setShowWelcome(false)
+        if (tourId) {
+            startTour(tourId)
+        }
+    }
+
+    const handleSkip = () => {
+        setShowWelcome(false)
+        // Mark as dismissed so modal won't show again on refresh
+        // User can restart via sidebar help button
+        if (tourId) {
+            markTourDismissed(tourId)
+        }
+    }
+
+    // Get display name - always include "Environment" suffix
+    const displayName = environmentName || (
+        environment === "python" ? "Python Environment" :
+            environment === "web" ? "Web Environment" :
+                environment === "r" ? "R Environment" :
+                    environment === "flowscape" ? "FlowScape Environment" :
+                        "CodeScapes"
+    )
+
+    return (
+        <TourWelcomeModal
+            open={showWelcome}
+            onStart={handleStart}
+            onSkip={handleSkip}
+            environmentName={displayName}
+        />
+    )
+}
+
+// Export function to reset tour state (for testing)
+export function resetTourAutoStart() {
+    hasShownModal = false
+}

--- a/src/components/tour/TourBeacon.tsx
+++ b/src/components/tour/TourBeacon.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { useEffect, useState } from "react"
+import { createPortal } from "react-dom"
+
+interface TourBeaconProps {
+    /** CSS selector for the target element */
+    target: string
+    /** Beacon label text */
+    label?: string
+    /** Show arrow pointing to target */
+    showArrow?: boolean
+}
+
+export function TourBeacon({ target, label = "Click here", showArrow = true }: TourBeaconProps) {
+    const [targetRect, setTargetRect] = useState<DOMRect | null>(null)
+    const [mounted, setMounted] = useState(false)
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Valid pattern for portal mount detection
+    useEffect(() => {
+        setMounted(true)
+        return () => setMounted(false)
+    }, [])
+
+    useEffect(() => {
+        const updatePosition = () => {
+            const element = document.querySelector(target)
+            if (element) {
+                setTargetRect(element.getBoundingClientRect())
+            }
+        }
+
+        updatePosition()
+        window.addEventListener("resize", updatePosition)
+        window.addEventListener("scroll", updatePosition, true)
+
+        return () => {
+            window.removeEventListener("resize", updatePosition)
+            window.removeEventListener("scroll", updatePosition, true)
+        }
+    }, [target])
+
+    if (!mounted || !targetRect) return null
+
+    // Position beacon at the top-right corner of the target
+    const beaconStyle = {
+        left: targetRect.right - 12,
+        top: targetRect.top - 12,
+    }
+
+    return createPortal(
+        <div
+            className="fixed z-[9999] pointer-events-none"
+            style={beaconStyle}
+        >
+            {/* Pulsing beacon */}
+            <div className="relative">
+                {/* Outer pulse ring */}
+                <div className="absolute inset-0 w-6 h-6 rounded-full bg-blue-500/30 animate-ping" />
+
+                {/* Inner solid circle */}
+                <div className="relative w-6 h-6 rounded-full bg-blue-500 shadow-lg shadow-blue-500/50 flex items-center justify-center">
+                    <div className="w-2 h-2 rounded-full bg-white" />
+                </div>
+            </div>
+
+            {/* Label with arrow */}
+            {label && (
+                <div className="absolute left-8 top-1/2 -translate-y-1/2 flex items-center gap-1 whitespace-nowrap">
+                    {showArrow && (
+                        <svg
+                            className="w-4 h-4 text-blue-400 animate-bounce-x"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            strokeWidth="2"
+                        >
+                            <path d="M5 12h14M12 5l7 7-7 7" />
+                        </svg>
+                    )}
+                    <span className="px-2 py-1 text-xs font-medium text-white bg-blue-500 rounded-md shadow-lg">
+                        {label}
+                    </span>
+                </div>
+            )}
+        </div>,
+        document.body
+    )
+}

--- a/src/components/tour/TourPopover.tsx
+++ b/src/components/tour/TourPopover.tsx
@@ -1,0 +1,222 @@
+"use client"
+
+import { useEffect, useState, useRef } from "react"
+import { createPortal } from "react-dom"
+import {
+    X,
+    ChevronLeft,
+    ChevronRight,
+    Code,
+    Files,
+    Play,
+    RotateCw,
+    Zap,
+    Terminal,
+    BarChart3,
+    Box,
+    Lock,
+    type LucideIcon
+} from "lucide-react"
+import { Button } from "@/components/ui/button"
+import type { StepPosition } from "@/lib/tours/types"
+
+// Icon map for dynamic rendering
+const TOUR_ICONS: Record<string, LucideIcon> = {
+    Code,
+    Files,
+    Play,
+    RotateCw,
+    Zap,
+    Terminal,
+    BarChart3,
+    Box,
+    Lock,
+}
+
+interface TourPopoverProps {
+    /** CSS selector for the target element */
+    target: string
+    /** Step title */
+    title: string
+    /** Step description */
+    description: string
+    /** Position relative to target */
+    position?: StepPosition
+    /** Current step number (1-indexed for display) */
+    currentStep: number
+    /** Total number of steps */
+    totalSteps: number
+    /** Show back button */
+    showBack?: boolean
+    /** Show next button */
+    showNext?: boolean
+    /** Next button label */
+    nextLabel?: string
+    /** Callback for next */
+    onNext?: () => void
+    /** Callback for back */
+    onBack?: () => void
+    /** Callback for skip/exit */
+    onSkip?: () => void
+    /** Icon/emoji for the step */
+    icon?: string
+}
+
+export function TourPopover({
+    target,
+    title,
+    description,
+    position = "bottom",
+    currentStep,
+    totalSteps,
+    showBack = true,
+    showNext = true,
+    nextLabel = "Next",
+    onNext,
+    onBack,
+    onSkip,
+    icon,
+}: TourPopoverProps) {
+    const [targetRect, setTargetRect] = useState<DOMRect | null>(null)
+    const [mounted, setMounted] = useState(false)
+    const popoverRef = useRef<HTMLDivElement>(null)
+    const [popoverSize, setPopoverSize] = useState({ width: 320, height: 200 })
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Valid pattern for portal mount detection
+    useEffect(() => {
+        setMounted(true)
+        return () => setMounted(false)
+    }, [])
+
+    useEffect(() => {
+        const updatePosition = () => {
+            const element = document.querySelector(target)
+            if (element) {
+                setTargetRect(element.getBoundingClientRect())
+            }
+        }
+
+        updatePosition()
+        window.addEventListener("resize", updatePosition)
+        window.addEventListener("scroll", updatePosition, true)
+
+        return () => {
+            window.removeEventListener("resize", updatePosition)
+            window.removeEventListener("scroll", updatePosition, true)
+        }
+    }, [target])
+
+    // Measure popover size
+    useEffect(() => {
+        if (popoverRef.current) {
+            const rect = popoverRef.current.getBoundingClientRect()
+            setPopoverSize({ width: rect.width, height: rect.height })
+        }
+    }, [title, description])
+
+    if (!mounted || !targetRect) return null
+
+    // Calculate popover position
+    const gap = 16
+    let left = 0
+    let top = 0
+
+    switch (position) {
+        case "top":
+            left = targetRect.left + targetRect.width / 2 - popoverSize.width / 2
+            top = targetRect.top - popoverSize.height - gap
+            break
+        case "bottom":
+            left = targetRect.left + targetRect.width / 2 - popoverSize.width / 2
+            top = targetRect.bottom + gap
+            break
+        case "left":
+            left = targetRect.left - popoverSize.width - gap
+            top = targetRect.top + targetRect.height / 2 - popoverSize.height / 2
+            break
+        case "right":
+            left = targetRect.right + gap
+            top = targetRect.top + targetRect.height / 2 - popoverSize.height / 2
+            break
+        case "center":
+            left = window.innerWidth / 2 - popoverSize.width / 2
+            top = window.innerHeight / 2 - popoverSize.height / 2
+            break
+    }
+
+    // Keep within viewport
+    left = Math.max(16, Math.min(left, window.innerWidth - popoverSize.width - 16))
+    top = Math.max(16, Math.min(top, window.innerHeight - popoverSize.height - 16))
+
+    return createPortal(
+        <div
+            ref={popoverRef}
+            className="fixed z-[10000] w-80 max-w-[calc(100vw-32px)] bg-card border border-border rounded-xl shadow-2xl animate-in fade-in-0 zoom-in-95 duration-200"
+            style={{ left, top }}
+        >
+            {/* Header */}
+            <div className="flex items-start justify-between p-4 pb-2">
+                <div className="flex items-center gap-2">
+                    {icon && TOUR_ICONS[icon] && (
+                        (() => {
+                            const IconComponent = TOUR_ICONS[icon]
+                            return <IconComponent className="h-5 w-5 text-primary" />
+                        })()
+                    )}
+                    <h3 className="font-semibold text-foreground">{title}</h3>
+                </div>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    className="h-6 w-6 -mr-2 -mt-1 text-muted-foreground hover:text-foreground"
+                    onClick={onSkip}
+                >
+                    <X className="h-4 w-4" />
+                </Button>
+            </div>
+
+            {/* Description */}
+            <div className="px-4 pb-3">
+                <p className="text-sm text-muted-foreground leading-relaxed">{description}</p>
+            </div>
+
+            {/* Footer */}
+            <div className="flex items-center justify-between gap-4 px-4 py-3 border-t border-border bg-muted/30 rounded-b-xl">
+                {/* Progress dots */}
+                <div className="flex items-center gap-1 shrink-0">
+                    {Array.from({ length: totalSteps }, (_, i) => (
+                        <div
+                            key={i}
+                            className={`w-1.5 h-1.5 rounded-full transition-colors ${i === currentStep - 1
+                                ? "bg-primary"
+                                : i < currentStep - 1
+                                    ? "bg-primary/50"
+                                    : "bg-muted-foreground/30"
+                                }`}
+                        />
+                    ))}
+                    <span className="ml-2 text-xs text-muted-foreground whitespace-nowrap">
+                        {currentStep} of {totalSteps}
+                    </span>
+                </div>
+
+                {/* Navigation buttons */}
+                <div className="flex items-center gap-2">
+                    {showBack && currentStep > 1 && (
+                        <Button variant="ghost" size="sm" onClick={onBack} className="h-8 px-2">
+                            <ChevronLeft className="h-4 w-4 mr-1" />
+                            Back
+                        </Button>
+                    )}
+                    {showNext && (
+                        <Button size="sm" onClick={onNext} className="h-8">
+                            {nextLabel}
+                            <ChevronRight className="h-4 w-4 ml-1" />
+                        </Button>
+                    )}
+                </div>
+            </div>
+        </div>,
+        document.body
+    )
+}

--- a/src/components/tour/TourProvider.tsx
+++ b/src/components/tour/TourProvider.tsx
@@ -1,13 +1,13 @@
 "use client"
 
 import {
-    createContext,
-    useContext,
-    useState,
-    useCallback,
-    useEffect,
-    useMemo,
-    type ReactNode,
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useEffect,
+  useMemo,
+  type ReactNode,
 } from "react"
 import type { TourConfig, TourContextValue, TourState } from "@/lib/tours/types"
 import { supabase } from "@/lib/supabase"
@@ -17,81 +17,110 @@ const COMPLETED_TOURS_KEY = "codescapes_completed_tours"
 
 // Get completed tours from localStorage - SYNCHRONOUS for immediate availability
 function getCompletedToursSync(): string[] {
-    if (typeof window === "undefined") return []
-    try {
-        const stored = localStorage.getItem(COMPLETED_TOURS_KEY)
-        return stored ? JSON.parse(stored) : []
-    } catch {
-        return []
-    }
+  if (typeof window === "undefined") return []
+  try {
+    const stored = localStorage.getItem(COMPLETED_TOURS_KEY)
+    return stored ? JSON.parse(stored) : []
+  } catch {
+    return []
+  }
 }
 
 // Save completed tours to localStorage
 function saveCompletedToursLocal(tours: string[]) {
-    if (typeof window === "undefined") return
-    try {
-        localStorage.setItem(COMPLETED_TOURS_KEY, JSON.stringify(tours))
-    } catch {
-        // Ignore storage errors
-    }
+  if (typeof window === "undefined") return
+  try {
+    localStorage.setItem(COMPLETED_TOURS_KEY, JSON.stringify(tours))
+  } catch {
+    // Ignore storage errors
+  }
 }
 
 // Save completed tours to Supabase profile
 async function saveCompletedToursProfile(tours: string[]) {
-    try {
-        const { data: { user } } = await supabase.auth.getUser()
-        if (!user) return
-
-        await supabase
-            .from("profiles")
-            .update({
-                preferences: {
-                    completed_tours: tours
-                }
-            })
-            .eq("id", user.id)
-    } catch (error) {
-        console.error("[TourProvider] Failed to save to profile:", error)
+  try {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) {
+      console.log("[TourProvider] No user logged in, skipping profile save")
+      return
     }
+
+    console.log("[TourProvider] Saving to profile:", tours, "for user:", user.id)
+
+    const { error } = await supabase
+      .from("profiles")
+      .update({
+        preferences: {
+          completed_tours: tours,
+        },
+      })
+      .eq("id", user.id)
+
+    if (error) {
+      console.error("[TourProvider] Failed to save to profile:", error)
+    } else {
+      console.log("[TourProvider] Successfully saved to profile")
+    }
+  } catch (error) {
+    console.error("[TourProvider] Exception saving to profile:", error)
+  }
 }
 
 // Load completed tours from Supabase profile
 async function loadCompletedToursProfile(): Promise<string[]> {
-    try {
-        const { data: { user } } = await supabase.auth.getUser()
-        if (!user) return []
-
-        const { data } = await supabase
-            .from("profiles")
-            .select("preferences")
-            .eq("id", user.id)
-            .single()
-
-        if (data?.preferences?.completed_tours) {
-            return data.preferences.completed_tours
-        }
-        return []
-    } catch {
-        return []
+  try {
+    const {
+      data: { user },
+    } = await supabase.auth.getUser()
+    if (!user) {
+      console.log("[TourProvider] No user logged in, skipping profile load")
+      return []
     }
+
+    console.log("[TourProvider] Loading from profile for user:", user.id)
+
+    const { data, error } = await supabase
+      .from("profiles")
+      .select("preferences")
+      .eq("id", user.id)
+      .single()
+
+    if (error) {
+      console.error("[TourProvider] Failed to load from profile:", error)
+      return []
+    }
+
+    console.log("[TourProvider] Loaded preferences:", data?.preferences)
+
+    if (data?.preferences?.completed_tours) {
+      console.log("[TourProvider] Found completed_tours:", data.preferences.completed_tours)
+      return data.preferences.completed_tours
+    }
+    return []
+  } catch (error) {
+    console.error("[TourProvider] Exception loading from profile:", error)
+    return []
+  }
 }
 
 // Default context value
 const defaultContextValue: TourContextValue = {
-    activeTourId: null,
-    currentStepIndex: 0,
-    isActive: false,
-    stepCompleted: false,
-    startTour: () => { },
-    nextStep: () => { },
-    prevStep: () => { },
-    exitTour: () => { },
-    completeStep: () => { },
-    currentTour: null,
-    currentStep: null,
-    hasCompletedTour: () => false,
-    resetTour: () => { },
-    markTourDismissed: () => { },
+  activeTourId: null,
+  currentStepIndex: 0,
+  isActive: false,
+  stepCompleted: false,
+  startTour: () => {},
+  nextStep: () => {},
+  prevStep: () => {},
+  exitTour: () => {},
+  completeStep: () => {},
+  currentTour: null,
+  currentStep: null,
+  hasCompletedTour: () => false,
+  resetTour: () => {},
+  markTourDismissed: () => {},
 }
 
 // Create context
@@ -99,204 +128,210 @@ const TourContext = createContext<TourContextValue>(defaultContextValue)
 
 // Hook to consume tour context
 export function useTour() {
-    return useContext(TourContext)
+  return useContext(TourContext)
 }
 
 interface TourProviderProps {
-    children: ReactNode
-    /** Registry of available tours */
-    tours: Record<string, TourConfig>
-    /** Callback when tour completes */
-    onTourComplete?: (tourId: string) => void
+  children: ReactNode
+  /** Registry of available tours */
+  tours: Record<string, TourConfig>
+  /** Callback when tour completes */
+  onTourComplete?: (tourId: string) => void
 }
 
 export function TourProvider({ children, tours, onTourComplete }: TourProviderProps) {
-    const [state, setState] = useState<TourState>({
-        activeTourId: null,
+  const [state, setState] = useState<TourState>({
+    activeTourId: null,
+    currentStepIndex: 0,
+    isActive: false,
+    stepCompleted: false,
+  })
+
+  // CRITICAL: Initialize from localStorage SYNCHRONOUSLY to prevent race conditions
+  // This ensures hasCompletedTour returns correct value on first render
+  const [completedTours, setCompletedTours] = useState<string[]>(() => {
+    return getCompletedToursSync()
+  })
+
+  // Async merge with profile data (enhancement, not blocking)
+  useEffect(() => {
+    async function mergeWithProfile() {
+      const profileTours = await loadCompletedToursProfile()
+      if (profileTours.length === 0) return
+
+      setCompletedTours((current) => {
+        const merged = [...new Set([...current, ...profileTours])]
+        // Only update if there are new items from profile
+        if (merged.length > current.length) {
+          saveCompletedToursLocal(merged)
+          return merged
+        }
+        return current
+      })
+    }
+    mergeWithProfile()
+  }, [])
+
+  // Get current tour config
+  const currentTour = useMemo(() => {
+    if (!state.activeTourId) return null
+    return tours[state.activeTourId] || null
+  }, [state.activeTourId, tours])
+
+  // Get current step config
+  const currentStep = useMemo(() => {
+    if (!currentTour) return null
+    return currentTour.steps[state.currentStepIndex] || null
+  }, [currentTour, state.currentStepIndex])
+
+  // Helper to mark tour as completed (saves to both localStorage and profile)
+  const markTourCompleted = useCallback((tourId: string) => {
+    setCompletedTours((prev) => {
+      if (prev.includes(tourId)) return prev
+      const newCompleted = [...prev, tourId]
+      saveCompletedToursLocal(newCompleted)
+      saveCompletedToursProfile(newCompleted)
+      return newCompleted
+    })
+  }, [])
+
+  // Start a tour
+  const startTour = useCallback(
+    (tourId: string) => {
+      const tour = tours[tourId]
+      if (!tour || tour.steps.length === 0) {
+        console.warn(`[TourProvider] Tour "${tourId}" not found or has no steps`)
+        return
+      }
+
+      setState({
+        activeTourId: tourId,
         currentStepIndex: 0,
-        isActive: false,
+        isActive: true,
         stepCompleted: false,
+      })
+    },
+    [tours]
+  )
+
+  // Mark current step as completed
+  const completeStep = useCallback(() => {
+    setState((prev) => ({
+      ...prev,
+      stepCompleted: true,
+    }))
+  }, [])
+
+  // Advance to next step
+  const nextStep = useCallback(() => {
+    setState((prev) => {
+      if (!prev.activeTourId) return prev
+
+      const tour = tours[prev.activeTourId]
+      if (!tour) return prev
+
+      const nextIndex = prev.currentStepIndex + 1
+
+      // Tour complete
+      if (nextIndex >= tour.steps.length) {
+        markTourCompleted(prev.activeTourId)
+        onTourComplete?.(prev.activeTourId)
+
+        return {
+          activeTourId: null,
+          currentStepIndex: 0,
+          isActive: false,
+          stepCompleted: false,
+        }
+      }
+
+      return {
+        ...prev,
+        currentStepIndex: nextIndex,
+        stepCompleted: false,
+      }
     })
+  }, [tours, markTourCompleted, onTourComplete])
 
-    // CRITICAL: Initialize from localStorage SYNCHRONOUSLY to prevent race conditions
-    // This ensures hasCompletedTour returns correct value on first render
-    const [completedTours, setCompletedTours] = useState<string[]>(() => {
-        return getCompletedToursSync()
+  // Go back to previous step
+  const prevStep = useCallback(() => {
+    setState((prev) => {
+      if (prev.currentStepIndex <= 0) return prev
+      return {
+        ...prev,
+        currentStepIndex: prev.currentStepIndex - 1,
+        stepCompleted: false,
+      }
     })
+  }, [])
 
-    // Async merge with profile data (enhancement, not blocking)
-    useEffect(() => {
-        async function mergeWithProfile() {
-            const profileTours = await loadCompletedToursProfile()
-            if (profileTours.length === 0) return
+  // Exit/skip the tour - marks as completed so it won't show again
+  const exitTour = useCallback(() => {
+    if (state.activeTourId) {
+      markTourCompleted(state.activeTourId)
+    }
 
-            setCompletedTours((current) => {
-                const merged = [...new Set([...current, ...profileTours])]
-                // Only update if there are new items from profile
-                if (merged.length > current.length) {
-                    saveCompletedToursLocal(merged)
-                    return merged
-                }
-                return current
-            })
-        }
-        mergeWithProfile()
-    }, [])
+    setState({
+      activeTourId: null,
+      currentStepIndex: 0,
+      isActive: false,
+      stepCompleted: false,
+    })
+  }, [state.activeTourId, markTourCompleted])
 
-    // Get current tour config
-    const currentTour = useMemo(() => {
-        if (!state.activeTourId) return null
-        return tours[state.activeTourId] || null
-    }, [state.activeTourId, tours])
+  // Check if a tour has been completed
+  const hasCompletedTour = useCallback(
+    (tourId: string) => completedTours.includes(tourId),
+    [completedTours]
+  )
 
-    // Get current step config
-    const currentStep = useMemo(() => {
-        if (!currentTour) return null
-        return currentTour.steps[state.currentStepIndex] || null
-    }, [currentTour, state.currentStepIndex])
+  // Reset a tour's completion status (for restart)
+  const resetTour = useCallback((tourId: string) => {
+    setCompletedTours((prev) => {
+      const newCompleted = prev.filter((id) => id !== tourId)
+      saveCompletedToursLocal(newCompleted)
+      saveCompletedToursProfile(newCompleted)
+      return newCompleted
+    })
+  }, [])
 
-    // Helper to mark tour as completed (saves to both localStorage and profile)
-    const markTourCompleted = useCallback((tourId: string) => {
-        setCompletedTours((prev) => {
-            if (prev.includes(tourId)) return prev
-            const newCompleted = [...prev, tourId]
-            saveCompletedToursLocal(newCompleted)
-            saveCompletedToursProfile(newCompleted)
-            return newCompleted
-        })
-    }, [])
+  // Mark a tour as dismissed (for skip/close) - same as completing it
+  const markTourDismissed = useCallback(
+    (tourId: string) => {
+      markTourCompleted(tourId)
+    },
+    [markTourCompleted]
+  )
 
-    // Start a tour
-    const startTour = useCallback((tourId: string) => {
-        const tour = tours[tourId]
-        if (!tour || tour.steps.length === 0) {
-            console.warn(`[TourProvider] Tour "${tourId}" not found or has no steps`)
-            return
-        }
+  // Context value
+  const contextValue = useMemo<TourContextValue>(
+    () => ({
+      ...state,
+      startTour,
+      nextStep,
+      prevStep,
+      exitTour,
+      completeStep,
+      currentTour,
+      currentStep,
+      hasCompletedTour,
+      resetTour,
+      markTourDismissed,
+    }),
+    [
+      state,
+      startTour,
+      nextStep,
+      prevStep,
+      exitTour,
+      completeStep,
+      currentTour,
+      currentStep,
+      hasCompletedTour,
+      resetTour,
+      markTourDismissed,
+    ]
+  )
 
-        setState({
-            activeTourId: tourId,
-            currentStepIndex: 0,
-            isActive: true,
-            stepCompleted: false,
-        })
-    }, [tours])
-
-    // Mark current step as completed
-    const completeStep = useCallback(() => {
-        setState((prev) => ({
-            ...prev,
-            stepCompleted: true,
-        }))
-    }, [])
-
-    // Advance to next step
-    const nextStep = useCallback(() => {
-        setState((prev) => {
-            if (!prev.activeTourId) return prev
-
-            const tour = tours[prev.activeTourId]
-            if (!tour) return prev
-
-            const nextIndex = prev.currentStepIndex + 1
-
-            // Tour complete
-            if (nextIndex >= tour.steps.length) {
-                markTourCompleted(prev.activeTourId)
-                onTourComplete?.(prev.activeTourId)
-
-                return {
-                    activeTourId: null,
-                    currentStepIndex: 0,
-                    isActive: false,
-                    stepCompleted: false,
-                }
-            }
-
-            return {
-                ...prev,
-                currentStepIndex: nextIndex,
-                stepCompleted: false,
-            }
-        })
-    }, [tours, markTourCompleted, onTourComplete])
-
-    // Go back to previous step
-    const prevStep = useCallback(() => {
-        setState((prev) => {
-            if (prev.currentStepIndex <= 0) return prev
-            return {
-                ...prev,
-                currentStepIndex: prev.currentStepIndex - 1,
-                stepCompleted: false,
-            }
-        })
-    }, [])
-
-    // Exit/skip the tour - marks as completed so it won't show again
-    const exitTour = useCallback(() => {
-        if (state.activeTourId) {
-            markTourCompleted(state.activeTourId)
-        }
-
-        setState({
-            activeTourId: null,
-            currentStepIndex: 0,
-            isActive: false,
-            stepCompleted: false,
-        })
-    }, [state.activeTourId, markTourCompleted])
-
-    // Check if a tour has been completed
-    const hasCompletedTour = useCallback(
-        (tourId: string) => completedTours.includes(tourId),
-        [completedTours]
-    )
-
-    // Reset a tour's completion status (for restart)
-    const resetTour = useCallback((tourId: string) => {
-        setCompletedTours((prev) => {
-            const newCompleted = prev.filter((id) => id !== tourId)
-            saveCompletedToursLocal(newCompleted)
-            saveCompletedToursProfile(newCompleted)
-            return newCompleted
-        })
-    }, [])
-
-    // Mark a tour as dismissed (for skip/close) - same as completing it
-    const markTourDismissed = useCallback((tourId: string) => {
-        markTourCompleted(tourId)
-    }, [markTourCompleted])
-
-    // Context value
-    const contextValue = useMemo<TourContextValue>(
-        () => ({
-            ...state,
-            startTour,
-            nextStep,
-            prevStep,
-            exitTour,
-            completeStep,
-            currentTour,
-            currentStep,
-            hasCompletedTour,
-            resetTour,
-            markTourDismissed,
-        }),
-        [
-            state,
-            startTour,
-            nextStep,
-            prevStep,
-            exitTour,
-            completeStep,
-            currentTour,
-            currentStep,
-            hasCompletedTour,
-            resetTour,
-            markTourDismissed,
-        ]
-    )
-
-    return <TourContext.Provider value={contextValue}>{children}</TourContext.Provider>
+  return <TourContext.Provider value={contextValue}>{children}</TourContext.Provider>
 }

--- a/src/components/tour/TourProvider.tsx
+++ b/src/components/tour/TourProvider.tsx
@@ -1,0 +1,302 @@
+"use client"
+
+import {
+    createContext,
+    useContext,
+    useState,
+    useCallback,
+    useEffect,
+    useMemo,
+    type ReactNode,
+} from "react"
+import type { TourConfig, TourContextValue, TourState } from "@/lib/tours/types"
+import { supabase } from "@/lib/supabase"
+
+// Storage key for completed tours
+const COMPLETED_TOURS_KEY = "codescapes_completed_tours"
+
+// Get completed tours from localStorage - SYNCHRONOUS for immediate availability
+function getCompletedToursSync(): string[] {
+    if (typeof window === "undefined") return []
+    try {
+        const stored = localStorage.getItem(COMPLETED_TOURS_KEY)
+        return stored ? JSON.parse(stored) : []
+    } catch {
+        return []
+    }
+}
+
+// Save completed tours to localStorage
+function saveCompletedToursLocal(tours: string[]) {
+    if (typeof window === "undefined") return
+    try {
+        localStorage.setItem(COMPLETED_TOURS_KEY, JSON.stringify(tours))
+    } catch {
+        // Ignore storage errors
+    }
+}
+
+// Save completed tours to Supabase profile
+async function saveCompletedToursProfile(tours: string[]) {
+    try {
+        const { data: { user } } = await supabase.auth.getUser()
+        if (!user) return
+
+        await supabase
+            .from("profiles")
+            .update({
+                preferences: {
+                    completed_tours: tours
+                }
+            })
+            .eq("id", user.id)
+    } catch (error) {
+        console.error("[TourProvider] Failed to save to profile:", error)
+    }
+}
+
+// Load completed tours from Supabase profile
+async function loadCompletedToursProfile(): Promise<string[]> {
+    try {
+        const { data: { user } } = await supabase.auth.getUser()
+        if (!user) return []
+
+        const { data } = await supabase
+            .from("profiles")
+            .select("preferences")
+            .eq("id", user.id)
+            .single()
+
+        if (data?.preferences?.completed_tours) {
+            return data.preferences.completed_tours
+        }
+        return []
+    } catch {
+        return []
+    }
+}
+
+// Default context value
+const defaultContextValue: TourContextValue = {
+    activeTourId: null,
+    currentStepIndex: 0,
+    isActive: false,
+    stepCompleted: false,
+    startTour: () => { },
+    nextStep: () => { },
+    prevStep: () => { },
+    exitTour: () => { },
+    completeStep: () => { },
+    currentTour: null,
+    currentStep: null,
+    hasCompletedTour: () => false,
+    resetTour: () => { },
+    markTourDismissed: () => { },
+}
+
+// Create context
+const TourContext = createContext<TourContextValue>(defaultContextValue)
+
+// Hook to consume tour context
+export function useTour() {
+    return useContext(TourContext)
+}
+
+interface TourProviderProps {
+    children: ReactNode
+    /** Registry of available tours */
+    tours: Record<string, TourConfig>
+    /** Callback when tour completes */
+    onTourComplete?: (tourId: string) => void
+}
+
+export function TourProvider({ children, tours, onTourComplete }: TourProviderProps) {
+    const [state, setState] = useState<TourState>({
+        activeTourId: null,
+        currentStepIndex: 0,
+        isActive: false,
+        stepCompleted: false,
+    })
+
+    // CRITICAL: Initialize from localStorage SYNCHRONOUSLY to prevent race conditions
+    // This ensures hasCompletedTour returns correct value on first render
+    const [completedTours, setCompletedTours] = useState<string[]>(() => {
+        return getCompletedToursSync()
+    })
+
+    // Async merge with profile data (enhancement, not blocking)
+    useEffect(() => {
+        async function mergeWithProfile() {
+            const profileTours = await loadCompletedToursProfile()
+            if (profileTours.length === 0) return
+
+            setCompletedTours((current) => {
+                const merged = [...new Set([...current, ...profileTours])]
+                // Only update if there are new items from profile
+                if (merged.length > current.length) {
+                    saveCompletedToursLocal(merged)
+                    return merged
+                }
+                return current
+            })
+        }
+        mergeWithProfile()
+    }, [])
+
+    // Get current tour config
+    const currentTour = useMemo(() => {
+        if (!state.activeTourId) return null
+        return tours[state.activeTourId] || null
+    }, [state.activeTourId, tours])
+
+    // Get current step config
+    const currentStep = useMemo(() => {
+        if (!currentTour) return null
+        return currentTour.steps[state.currentStepIndex] || null
+    }, [currentTour, state.currentStepIndex])
+
+    // Helper to mark tour as completed (saves to both localStorage and profile)
+    const markTourCompleted = useCallback((tourId: string) => {
+        setCompletedTours((prev) => {
+            if (prev.includes(tourId)) return prev
+            const newCompleted = [...prev, tourId]
+            saveCompletedToursLocal(newCompleted)
+            saveCompletedToursProfile(newCompleted)
+            return newCompleted
+        })
+    }, [])
+
+    // Start a tour
+    const startTour = useCallback((tourId: string) => {
+        const tour = tours[tourId]
+        if (!tour || tour.steps.length === 0) {
+            console.warn(`[TourProvider] Tour "${tourId}" not found or has no steps`)
+            return
+        }
+
+        setState({
+            activeTourId: tourId,
+            currentStepIndex: 0,
+            isActive: true,
+            stepCompleted: false,
+        })
+    }, [tours])
+
+    // Mark current step as completed
+    const completeStep = useCallback(() => {
+        setState((prev) => ({
+            ...prev,
+            stepCompleted: true,
+        }))
+    }, [])
+
+    // Advance to next step
+    const nextStep = useCallback(() => {
+        setState((prev) => {
+            if (!prev.activeTourId) return prev
+
+            const tour = tours[prev.activeTourId]
+            if (!tour) return prev
+
+            const nextIndex = prev.currentStepIndex + 1
+
+            // Tour complete
+            if (nextIndex >= tour.steps.length) {
+                markTourCompleted(prev.activeTourId)
+                onTourComplete?.(prev.activeTourId)
+
+                return {
+                    activeTourId: null,
+                    currentStepIndex: 0,
+                    isActive: false,
+                    stepCompleted: false,
+                }
+            }
+
+            return {
+                ...prev,
+                currentStepIndex: nextIndex,
+                stepCompleted: false,
+            }
+        })
+    }, [tours, markTourCompleted, onTourComplete])
+
+    // Go back to previous step
+    const prevStep = useCallback(() => {
+        setState((prev) => {
+            if (prev.currentStepIndex <= 0) return prev
+            return {
+                ...prev,
+                currentStepIndex: prev.currentStepIndex - 1,
+                stepCompleted: false,
+            }
+        })
+    }, [])
+
+    // Exit/skip the tour - marks as completed so it won't show again
+    const exitTour = useCallback(() => {
+        if (state.activeTourId) {
+            markTourCompleted(state.activeTourId)
+        }
+
+        setState({
+            activeTourId: null,
+            currentStepIndex: 0,
+            isActive: false,
+            stepCompleted: false,
+        })
+    }, [state.activeTourId, markTourCompleted])
+
+    // Check if a tour has been completed
+    const hasCompletedTour = useCallback(
+        (tourId: string) => completedTours.includes(tourId),
+        [completedTours]
+    )
+
+    // Reset a tour's completion status (for restart)
+    const resetTour = useCallback((tourId: string) => {
+        setCompletedTours((prev) => {
+            const newCompleted = prev.filter((id) => id !== tourId)
+            saveCompletedToursLocal(newCompleted)
+            saveCompletedToursProfile(newCompleted)
+            return newCompleted
+        })
+    }, [])
+
+    // Mark a tour as dismissed (for skip/close) - same as completing it
+    const markTourDismissed = useCallback((tourId: string) => {
+        markTourCompleted(tourId)
+    }, [markTourCompleted])
+
+    // Context value
+    const contextValue = useMemo<TourContextValue>(
+        () => ({
+            ...state,
+            startTour,
+            nextStep,
+            prevStep,
+            exitTour,
+            completeStep,
+            currentTour,
+            currentStep,
+            hasCompletedTour,
+            resetTour,
+            markTourDismissed,
+        }),
+        [
+            state,
+            startTour,
+            nextStep,
+            prevStep,
+            exitTour,
+            completeStep,
+            currentTour,
+            currentStep,
+            hasCompletedTour,
+            resetTour,
+            markTourDismissed,
+        ]
+    )
+
+    return <TourContext.Provider value={contextValue}>{children}</TourContext.Provider>
+}

--- a/src/components/tour/TourRestartButton.tsx
+++ b/src/components/tour/TourRestartButton.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { useTour } from "./TourProvider"
+import { getTourForEnvironment } from "@/lib/tours"
+
+interface TourRestartButtonProps {
+    /** Environment to restart tour for */
+    environment: string
+}
+
+/**
+ * TourRestartButtonWrapper - Hidden helper that provides a clickable element
+ * for restarting the tour. Used with document.getElementById('tour-restart-btn')
+ * Must be placed inside TourProvider
+ */
+export function TourRestartButtonWrapper({ environment }: TourRestartButtonProps) {
+    const { resetTour, startTour } = useTour()
+
+    const handleClick = () => {
+        const tour = getTourForEnvironment(environment)
+        if (!tour) return
+
+        // Reset completion status and start tour
+        resetTour(tour.id)
+        startTour(tour.id)
+    }
+
+    // Hidden button that can be triggered programmatically
+    return (
+        <button
+            id="tour-restart-btn"
+            onClick={handleClick}
+            style={{ display: 'none' }}
+            aria-hidden="true"
+        />
+    )
+}

--- a/src/components/tour/TourSpotlight.tsx
+++ b/src/components/tour/TourSpotlight.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useEffect, useState, useRef } from "react"
+import { createPortal } from "react-dom"
+
+interface TourSpotlightProps {
+    /** CSS selector for the target element */
+    target: string
+    /** Padding around the target cutout */
+    padding?: number
+    /** Click handler for the spotlight overlay */
+    onOverlayClick?: () => void
+    /** Whether clicking outside target advances the tour */
+    allowOutsideClick?: boolean
+}
+
+export function TourSpotlight({
+    target,
+    padding = 8,
+    onOverlayClick,
+    allowOutsideClick = false,
+}: TourSpotlightProps) {
+    const [targetRect, setTargetRect] = useState<DOMRect | null>(null)
+    const [mounted, setMounted] = useState(false)
+    const observerRef = useRef<ResizeObserver | null>(null)
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect -- Valid pattern for portal mount detection
+    useEffect(() => {
+        setMounted(true)
+        return () => setMounted(false)
+    }, [])
+
+    useEffect(() => {
+        const updatePosition = () => {
+            const element = document.querySelector(target)
+            if (element) {
+                setTargetRect(element.getBoundingClientRect())
+            }
+        }
+
+        // Initial position
+        updatePosition()
+
+        // Watch for resize/scroll
+        window.addEventListener("resize", updatePosition)
+        window.addEventListener("scroll", updatePosition, true)
+
+        // Observe target element for size changes
+        const element = document.querySelector(target)
+        if (element) {
+            observerRef.current = new ResizeObserver(updatePosition)
+            observerRef.current.observe(element)
+        }
+
+        return () => {
+            window.removeEventListener("resize", updatePosition)
+            window.removeEventListener("scroll", updatePosition, true)
+            observerRef.current?.disconnect()
+        }
+    }, [target])
+
+    if (!mounted || !targetRect) return null
+
+    // Calculate cutout dimensions with padding
+    const cutout = {
+        x: targetRect.left - padding,
+        y: targetRect.top - padding,
+        width: targetRect.width + padding * 2,
+        height: targetRect.height + padding * 2,
+        rx: 8, // border-radius
+    }
+
+    const handleClick = (e: React.MouseEvent) => {
+        if (allowOutsideClick) {
+            onOverlayClick?.()
+        }
+        e.stopPropagation()
+    }
+
+    return createPortal(
+        <div
+            className="fixed inset-0 z-[9998]"
+            style={{ isolation: "isolate", pointerEvents: "none" }}
+        >
+            <svg
+                className="absolute inset-0 w-full h-full"
+                style={{ pointerEvents: "none" }}
+            >
+                <defs>
+                    <mask id="tour-spotlight-mask">
+                        <rect width="100%" height="100%" fill="white" />
+                        <rect
+                            x={cutout.x}
+                            y={cutout.y}
+                            width={cutout.width}
+                            height={cutout.height}
+                            rx={cutout.rx}
+                            fill="black"
+                        />
+                    </mask>
+                </defs>
+                {/* Dark overlay with hole - blocks clicks outside target */}
+                <rect
+                    width="100%"
+                    height="100%"
+                    fill="rgba(0, 0, 0, 0.75)"
+                    mask="url(#tour-spotlight-mask)"
+                    style={{ pointerEvents: "auto" }}
+                    onClick={handleClick}
+                />
+            </svg>
+
+            {/* Glow effect around target - does NOT block clicks */}
+            <div
+                className="absolute rounded-lg shadow-[0_0_0_4px_rgba(59,130,246,0.5)] pointer-events-none animate-pulse"
+                style={{
+                    left: cutout.x,
+                    top: cutout.y,
+                    width: cutout.width,
+                    height: cutout.height,
+                    borderRadius: cutout.rx,
+                }}
+            />
+        </div>,
+        document.body
+    )
+}

--- a/src/components/tour/TourStep.tsx
+++ b/src/components/tour/TourStep.tsx
@@ -1,0 +1,151 @@
+"use client"
+
+import { useEffect, useRef } from "react"
+import { useTour } from "./TourProvider"
+import { TourSpotlight } from "./TourSpotlight"
+import { TourBeacon } from "./TourBeacon"
+import { TourPopover } from "./TourPopover"
+
+/**
+ * TourStep - Main orchestrator component
+ * Renders spotlight, beacon, and popover based on current tour state
+ * Handles step completion detection (click, type, etc.)
+ */
+export function TourStep() {
+    const {
+        isActive,
+        currentStep,
+        currentTour,
+        currentStepIndex,
+        stepCompleted,
+        nextStep,
+        prevStep,
+        exitTour,
+        completeStep,
+    } = useTour()
+
+    const celebrationTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+    const autoAdvanceTimeoutRef = useRef<NodeJS.Timeout | null>(null)
+
+    // Handle click detection for "click" type steps
+    useEffect(() => {
+        if (!isActive || !currentStep || currentStep.type !== "click") return
+
+        const handleClick = (e: MouseEvent) => {
+            const target = document.querySelector(currentStep.target)
+            if (!target) return
+
+            // Check if click was on target or inside target
+            if (target.contains(e.target as Node)) {
+                completeStep()
+            }
+        }
+
+        // Use capture to catch clicks before they're handled
+        document.addEventListener("click", handleClick, true)
+        return () => document.removeEventListener("click", handleClick, true)
+    }, [isActive, currentStep, completeStep])
+
+    // Handle auto-advance for "observe" type steps ONLY if autoAdvanceDelay is explicitly set
+    useEffect(() => {
+        if (!isActive || !currentStep || currentStep.type !== "observe") return
+
+        // Only auto-advance if explicitly configured - user controls pace by default
+        if (!currentStep.autoAdvanceDelay) return
+
+        autoAdvanceTimeoutRef.current = setTimeout(() => {
+            nextStep()
+        }, currentStep.autoAdvanceDelay)
+
+        return () => {
+            if (autoAdvanceTimeoutRef.current) {
+                clearTimeout(autoAdvanceTimeoutRef.current)
+            }
+        }
+    }, [isActive, currentStep, nextStep])
+
+    // Handle celebration + auto-advance after step completion
+    useEffect(() => {
+        if (!stepCompleted || !currentStep) return
+
+        // Show celebration briefly, then advance
+        const celebrationDuration = currentStep.celebration ? 1500 : 500
+        celebrationTimeoutRef.current = setTimeout(() => {
+            nextStep()
+        }, celebrationDuration)
+
+        return () => {
+            if (celebrationTimeoutRef.current) {
+                clearTimeout(celebrationTimeoutRef.current)
+            }
+        }
+    }, [stepCompleted, currentStep, nextStep])
+
+    // Keyboard navigation
+    useEffect(() => {
+        if (!isActive) return
+
+        const handleKeyDown = (e: KeyboardEvent) => {
+            if (e.key === "Escape") {
+                exitTour()
+            } else if (e.key === "ArrowRight" && currentStep?.type === "observe") {
+                nextStep()
+            } else if (e.key === "ArrowLeft" && currentStepIndex > 0) {
+                prevStep()
+            }
+        }
+
+        document.addEventListener("keydown", handleKeyDown)
+        return () => document.removeEventListener("keydown", handleKeyDown)
+    }, [isActive, exitTour, nextStep, prevStep, currentStep, currentStepIndex])
+
+    // Debug log tour state
+    console.log("[TourStep] Render check - isActive:", isActive, "currentStep:", currentStep?.id, "currentTour:", currentTour?.id)
+
+    // Don't render if tour not active
+    if (!isActive || !currentStep || !currentTour) {
+        console.log("[TourStep] NOT rendering - conditions not met")
+        return null
+    }
+    console.log("[TourStep] RENDERING step:", currentStep.id, "target:", currentStep.target)
+
+    const totalSteps = currentTour.steps.length
+    const isFirstStep = currentStepIndex === 0
+    const isLastStep = currentStepIndex === totalSteps - 1
+    const showBeacon = currentStep.beacon !== false && currentStep.type === "click"
+
+    return (
+        <>
+            {/* Spotlight overlay */}
+            <TourSpotlight
+                target={currentStep.target}
+                allowOutsideClick={false}
+            />
+
+            {/* Beacon indicator for click steps */}
+            {showBeacon && !stepCompleted && (
+                <TourBeacon
+                    target={currentStep.target}
+                    label="Click here"
+                />
+            )}
+
+            {/* Popover with step content */}
+            <TourPopover
+                target={currentStep.target}
+                title={stepCompleted && currentStep.celebration ? "✨ " + currentStep.celebration : currentStep.title}
+                description={stepCompleted && currentStep.celebration ? "" : currentStep.description}
+                position={currentStep.position || "bottom"}
+                currentStep={currentStepIndex + 1}
+                totalSteps={totalSteps}
+                showBack={!isFirstStep && !stepCompleted}
+                showNext={!stepCompleted}
+                nextLabel={isLastStep ? "Done" : "Next"}
+                onNext={nextStep}
+                onBack={prevStep}
+                onSkip={exitTour}
+                icon={currentStep.icon}
+            />
+        </>
+    )
+}

--- a/src/components/tour/TourWelcomeModal.tsx
+++ b/src/components/tour/TourWelcomeModal.tsx
@@ -1,0 +1,72 @@
+"use client"
+
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+} from "@/components/ui/dialog"
+import { Button } from "@/components/ui/button"
+import { Sparkles, Check } from "lucide-react"
+
+interface TourWelcomeModalProps {
+    open: boolean
+    onStart: () => void
+    onSkip: () => void
+    environmentName?: string
+}
+
+/**
+ * TourWelcomeModal - Opt-in modal asking if user wants a guided tour
+ */
+export function TourWelcomeModal({
+    open,
+    onStart,
+    onSkip,
+    environmentName = "CodeScapes",
+}: TourWelcomeModalProps) {
+    return (
+        <Dialog open={open} onOpenChange={(isOpen) => !isOpen && onSkip()}>
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle className="flex items-center gap-2 text-xl">
+                        <Sparkles className="h-5 w-5 text-primary" />
+                        Welcome to {environmentName}!
+                    </DialogTitle>
+                    <DialogDescription className="text-base pt-2">
+                        Would you like a quick guided tour? We'll show you around in about 60 seconds.
+                    </DialogDescription>
+                </DialogHeader>
+
+                <div className="py-4">
+                    <ul className="space-y-2 text-sm text-muted-foreground">
+                        <li className="flex items-center gap-2">
+                            <Check className="h-4 w-4 text-primary" />
+                            Learn how to run your code
+                        </li>
+                        <li className="flex items-center gap-2">
+                            <Check className="h-4 w-4 text-primary" />
+                            See where your output appears
+                        </li>
+                        <li className="flex items-center gap-2">
+                            <Check className="h-4 w-4 text-primary" />
+                            Discover helpful features
+                        </li>
+                    </ul>
+                </div>
+
+                <DialogFooter className="flex gap-2 sm:gap-0">
+                    <Button variant="ghost" onClick={onSkip}>
+                        Skip for now
+                    </Button>
+                    <Button onClick={onStart}>
+                        Start Tour
+                        <Sparkles className="ml-2 h-4 w-4" />
+                    </Button>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/components/tour/index.ts
+++ b/src/components/tour/index.ts
@@ -1,0 +1,9 @@
+// Tour Components - Central Export
+export { TourProvider, useTour } from "./TourProvider"
+export { TourStep } from "./TourStep"
+export { TourAutoStart } from "./TourAutoStart"
+export { TourWelcomeModal } from "./TourWelcomeModal"
+export { TourRestartButtonWrapper } from "./TourRestartButton"
+export { TourSpotlight } from "./TourSpotlight"
+export { TourBeacon } from "./TourBeacon"
+export { TourPopover } from "./TourPopover"

--- a/src/lib/tours/flowscape-tour.ts
+++ b/src/lib/tours/flowscape-tour.ts
@@ -1,0 +1,54 @@
+/**
+ * FlowScape Tour
+ * Interactive onboarding for visual block-based programming
+ */
+import type { TourConfig } from "./types"
+
+export const flowscapeTour: TourConfig = {
+    id: "flowscape-intro",
+    name: "FlowScape",
+    environment: "flowscape",
+    showOnFirstVisit: true,
+    steps: [
+        {
+            id: "welcome",
+            type: "observe",
+            target: "[data-tour='flow-canvas']",
+            title: "Welcome to FlowScape! 🧩",
+            description: "Build programs visually by connecting blocks!",
+            position: "center",
+            icon: "👋",
+            autoAdvanceDelay: 3000,
+        },
+        {
+            id: "toolbox",
+            type: "click",
+            target: "[data-tour='block-toolbox']",
+            title: "Block Toolbox",
+            description: "Drag blocks from here onto the canvas to start building.",
+            position: "right",
+            beacon: true,
+            celebration: "Great!",
+        },
+        {
+            id: "run-button",
+            type: "click",
+            target: "[data-tour='run-button']",
+            title: "Run Your Flow",
+            description: "Click Run to execute your visual program!",
+            position: "bottom",
+            beacon: true,
+            celebration: "Running!",
+        },
+        {
+            id: "complete",
+            type: "observe",
+            target: "[data-tour='flow-canvas']",
+            title: "Start Creating! 🚀",
+            description: "Drag, connect, and run. No typing required!",
+            position: "center",
+            icon: "🎉",
+            autoAdvanceDelay: 2500,
+        },
+    ],
+}

--- a/src/lib/tours/index.ts
+++ b/src/lib/tours/index.ts
@@ -1,0 +1,42 @@
+/**
+ * Tour Registry
+ * Central export for all tour configurations
+ */
+import type { TourConfig } from "./types"
+import { pythonTour } from "./python-tour"
+import { webTour } from "./web-tour"
+import { rTour } from "./r-tour"
+import { flowscapeTour } from "./flowscape-tour"
+
+// Export individual tours
+export { pythonTour } from "./python-tour"
+export { webTour } from "./web-tour"
+export { rTour } from "./r-tour"
+export { flowscapeTour } from "./flowscape-tour"
+export type { TourConfig, TourStep, StepType, StepPosition } from "./types"
+
+// Tour registry by ID
+export const tourRegistry: Record<string, TourConfig> = {
+    "python-intro": pythonTour,
+    "web-intro": webTour,
+    "r-intro": rTour,
+    "flowscape-intro": flowscapeTour,
+}
+
+// Get tour by environment
+export function getTourForEnvironment(environment: string): TourConfig | null {
+    switch (environment) {
+        case "python":
+            return pythonTour
+        case "web":
+        case "javascript":
+        case "html":
+            return webTour
+        case "r":
+            return rTour
+        case "flowscape":
+            return flowscapeTour
+        default:
+            return null
+    }
+}

--- a/src/lib/tours/python-tour.ts
+++ b/src/lib/tours/python-tour.ts
@@ -1,0 +1,108 @@
+/**
+ * Python Environment Tour
+ * Interactive onboarding for Python/Pyodide projects
+ * 
+ * Tour Steps:
+ * 1. Code Editor - where you write Python code
+ * 2. File Explorer - manage your project files
+ * 3. Stop & Run - control code execution
+ * 4. Quick Run - re-run without stopping
+ * 5. Auto-run - automatic re-run on changes
+ * 6. Terminal - see print() output and errors
+ * 7. Output Pane - visualizations (plots, images, dataframes)
+ * 8. Packages Tab - install Python packages
+ * 9. Secrets Vault - store API keys securely
+ * 
+ * NOTE: No emojis - use Lucide icon names instead
+ */
+import type { TourConfig } from "./types"
+
+export const pythonTour: TourConfig = {
+    id: "python-intro",
+    name: "Python Environment",
+    environment: "python",
+    showOnFirstVisit: true,
+    steps: [
+        {
+            id: "code-editor",
+            type: "observe",
+            target: "[data-tour='code-editor']",
+            title: "Code Editor",
+            description: "This is where you write your Python code. It features syntax highlighting, auto-completion, and error detection.",
+            position: "right",
+            icon: "Code",
+        },
+        {
+            id: "file-explorer",
+            type: "observe",
+            target: "[data-tour='sidebar-explorer']",
+            title: "File Explorer",
+            description: "Manage your project files here. Create, rename, and organize Python files and assets.",
+            position: "right",
+            icon: "Files",
+        },
+        {
+            id: "stop-run",
+            type: "observe",
+            target: "[data-tour='run-button']",
+            title: "Stop & Run",
+            description: "Click the red Stop button to halt execution. Click the green Play button to run your code, or press Cmd+R (Ctrl+R).",
+            position: "bottom",
+            icon: "Play",
+        },
+        {
+            id: "quick-run",
+            type: "observe",
+            target: "[data-tour='quick-run-button']",
+            title: "Quick Re-run",
+            description: "No need to stop and restart! Click this refresh button to quickly re-run your code while it's already running.",
+            position: "bottom",
+            icon: "RotateCw",
+        },
+        {
+            id: "auto-toggle",
+            type: "observe",
+            target: "[data-tour='auto-toggle']",
+            title: "Auto-run Mode",
+            description: "Enable Auto mode to automatically re-run your code whenever you make changes. Great for rapid iteration!",
+            position: "bottom",
+            icon: "Zap",
+        },
+        {
+            id: "terminal",
+            type: "observe",
+            target: "[data-tour='terminal-pane']",
+            title: "Terminal",
+            description: "View print() statements, error messages, and interact with your running program here.",
+            position: "top",
+            icon: "Terminal",
+        },
+        {
+            id: "output-pane",
+            type: "observe",
+            target: "[data-tour='preview-pane']",
+            title: "Output & Visualizations",
+            description: "Matplotlib plots, Pandas DataFrames, Turtle graphics, and PIL images will appear in this panel.",
+            position: "left",
+            icon: "BarChart3",
+        },
+        {
+            id: "packages",
+            type: "observe",
+            target: "[data-tour='sidebar-packages']",
+            title: "Python Packages",
+            description: "Install packages like numpy, pandas, and matplotlib. Type 'pip install <package>' in the terminal or use this panel.",
+            position: "right",
+            icon: "Box",
+        },
+        {
+            id: "secrets",
+            type: "observe",
+            target: "[data-tour='sidebar-secrets']",
+            title: "Secrets Vault",
+            description: "Store API keys and sensitive data securely. Access them in your code using os.environ['KEY_NAME'].",
+            position: "right",
+            icon: "Lock",
+        },
+    ],
+}

--- a/src/lib/tours/r-tour.ts
+++ b/src/lib/tours/r-tour.ts
@@ -1,0 +1,54 @@
+/**
+ * R Environment Tour
+ * Interactive onboarding for R/RWebAssembly projects
+ */
+import type { TourConfig } from "./types"
+
+export const rTour: TourConfig = {
+    id: "r-intro",
+    name: "R Environment",
+    environment: "r",
+    showOnFirstVisit: true,
+    steps: [
+        {
+            id: "welcome",
+            type: "observe",
+            target: "[data-tour='code-editor']",
+            title: "Welcome to R in the Browser! 📊",
+            description: "Run R code with WebR - no installation needed.",
+            position: "center",
+            icon: "👋",
+            autoAdvanceDelay: 3000,
+        },
+        {
+            id: "run-button",
+            type: "click",
+            target: "[data-tour='run-button']",
+            title: "Run Your Script",
+            description: "Click Run to execute your R code. Built-in packages like ggplot2 are available.",
+            position: "bottom",
+            beacon: true,
+            celebration: "Running!",
+        },
+        {
+            id: "preview-pane",
+            type: "observe",
+            target: "[data-tour='preview-pane']",
+            title: "Plots & Output",
+            description: "R plots and data frames appear here. ggplot2 works beautifully!",
+            position: "left",
+            icon: "📈",
+            autoAdvanceDelay: 3500,
+        },
+        {
+            id: "complete",
+            type: "observe",
+            target: "[data-tour='code-editor']",
+            title: "Happy Analyzing! 🚀",
+            description: "Start exploring your data!",
+            position: "center",
+            icon: "🎉",
+            autoAdvanceDelay: 2500,
+        },
+    ],
+}

--- a/src/lib/tours/types.ts
+++ b/src/lib/tours/types.ts
@@ -1,0 +1,105 @@
+/**
+ * Tour System Types
+ * Defines the structure for interactive guided tours
+ */
+
+export type StepType = "click" | "observe" | "type" | "hover"
+export type StepPosition = "top" | "bottom" | "left" | "right" | "center"
+
+export interface TourStep {
+    /** Unique identifier for this step */
+    id: string
+
+    /** Type of interaction required */
+    type: StepType
+
+    /** CSS selector for the target element */
+    target: string
+
+    /** Step title (supports emoji) */
+    title: string
+
+    /** Step description */
+    description: string
+
+    /** Popover position relative to target */
+    position?: StepPosition
+
+    /** Show pulsing beacon on target */
+    beacon?: boolean
+
+    /** Message to show after step completion */
+    celebration?: string
+
+    /** Auto-advance delay in ms (for "observe" type) */
+    autoAdvanceDelay?: number
+
+    /** Required input text for "type" steps (partial match) */
+    requiredInput?: string
+
+    /** Optional icon for the step */
+    icon?: string
+}
+
+export interface TourConfig {
+    /** Unique tour identifier */
+    id: string
+
+    /** Display name for the tour */
+    name: string
+
+    /** Environment this tour is for (python, web, r, flowscape) */
+    environment?: string
+
+    /** Auto-start on first visit */
+    showOnFirstVisit: boolean
+
+    /** Tour steps */
+    steps: TourStep[]
+}
+
+export interface TourState {
+    /** Currently active tour ID */
+    activeTourId: string | null
+
+    /** Current step index */
+    currentStepIndex: number
+
+    /** Is tour currently running */
+    isActive: boolean
+
+    /** Has the current step been completed (action performed) */
+    stepCompleted: boolean
+}
+
+export interface TourContextValue extends TourState {
+    /** Start a tour by ID */
+    startTour: (tourId: string) => void
+
+    /** Advance to next step */
+    nextStep: () => void
+
+    /** Go back to previous step */
+    prevStep: () => void
+
+    /** Exit/skip the tour */
+    exitTour: () => void
+
+    /** Mark current step as completed */
+    completeStep: () => void
+
+    /** Get current tour config */
+    currentTour: TourConfig | null
+
+    /** Get current step config */
+    currentStep: TourStep | null
+
+    /** Check if a tour has been completed */
+    hasCompletedTour: (tourId: string) => boolean
+
+    /** Reset a tour's completion status */
+    resetTour: (tourId: string) => void
+
+    /** Mark a tour as dismissed (skip/close) - prevents showing again */
+    markTourDismissed: (tourId: string) => void
+}

--- a/src/lib/tours/web-tour.ts
+++ b/src/lib/tours/web-tour.ts
@@ -1,0 +1,89 @@
+/**
+ * Web Environment Tour
+ * Interactive onboarding for HTML/CSS/JS projects
+ * 
+ * Tour Steps:
+ * 1. Code Editor - where you write HTML/CSS/JS
+ * 2. File Explorer - manage your project files
+ * 3. Stop & Run - control code execution
+ * 4. Quick Run - re-run without stopping
+ * 5. Auto-run - automatic refresh on changes
+ * 6. Console - see errors and logs
+ * 7. Live Preview - see your webpage
+ * 
+ * NOTE: No emojis - use Lucide icon names instead
+ * NOTE: No packages step - web environment doesn't have npm packages in sidebar
+ */
+import type { TourConfig } from "./types"
+
+export const webTour: TourConfig = {
+    id: "web-intro",
+    name: "Web Environment",
+    environment: "web",
+    showOnFirstVisit: true,
+    steps: [
+        {
+            id: "code-editor",
+            type: "observe",
+            target: "[data-tour='code-editor']",
+            title: "Code Editor",
+            description: "Write your HTML, CSS, and JavaScript here. The editor supports syntax highlighting and auto-completion.",
+            position: "right",
+            icon: "Code",
+        },
+        {
+            id: "file-explorer",
+            type: "observe",
+            target: "[data-tour='sidebar-explorer']",
+            title: "File Explorer",
+            description: "Your project files are here. Browse index.html, styles.css, and script.js.",
+            position: "right",
+            icon: "Files",
+        },
+        {
+            id: "stop-run",
+            type: "observe",
+            target: "[data-tour='run-button']",
+            title: "Stop & Run",
+            description: "Click the red Stop button to halt the preview. Click the green Play button to run your project, or press Cmd+R (Ctrl+R).",
+            position: "bottom",
+            icon: "Play",
+        },
+        {
+            id: "quick-run",
+            type: "observe",
+            target: "[data-tour='quick-run-button']",
+            title: "Quick Refresh",
+            description: "Click this refresh button to quickly reload your webpage without stopping. Great for testing changes!",
+            position: "bottom",
+            icon: "RotateCw",
+        },
+        {
+            id: "auto-toggle",
+            type: "observe",
+            target: "[data-tour='auto-toggle']",
+            title: "Auto Refresh",
+            description: "Enable Auto mode to see your changes instantly as you type. The preview updates automatically!",
+            position: "bottom",
+            icon: "Zap",
+        },
+        {
+            id: "terminal",
+            type: "observe",
+            target: "[data-tour='terminal-pane']",
+            title: "Console",
+            description: "View console.log() output, JavaScript errors, and debugging information here.",
+            position: "top",
+            icon: "Terminal",
+        },
+        {
+            id: "output-pane",
+            type: "observe",
+            target: "[data-tour='preview-pane']",
+            title: "Live Preview",
+            description: "Your webpage renders here in real-time. See HTML, CSS, and JavaScript come to life!",
+            position: "left",
+            icon: "BarChart3",
+        },
+    ],
+}

--- a/src/pages/ScapeEditor.tsx
+++ b/src/pages/ScapeEditor.tsx
@@ -67,6 +67,8 @@ import { LoadingOverlay } from "@/components/ui/spinner"
 import { SourceControlPane } from "@/components/editor/SourceControlPane"
 import { initFromSupabase } from "@/lib/git/sync"
 import { useGitManager } from "@/hooks/useGitManager"
+import { TourProvider, TourStep, TourAutoStart, TourRestartButtonWrapper } from "@/components/tour"
+import { tourRegistry } from "@/lib/tours"
 
 // --- Helper for Persistence ---
 function usePersistentState<T>(
@@ -1180,13 +1182,23 @@ export default function ScapeEditor() {
     )
 
   return (
-    <>
+    <TourProvider tours={tourRegistry}>
+      <TourStep />
+      {scape?.environment && <TourAutoStart environment={scape.environment} />}
+      {/* TourRestartButton renders inside TourProvider to access context */}
+      {scape?.environment && (
+        <TourRestartButtonWrapper environment={scape.environment} />
+      )}
       <ScapeLayout
         sidebar={
           <EditorActivityBar
             activeTool={activeTool}
             onToolSelect={setActiveTool}
             onSettingsClick={() => setIsSettingsOpen(true)}
+            onHelpClick={() => {
+              // Trigger the restart button click programmatically
+              document.getElementById('tour-restart-btn')?.click()
+            }}
             topTools={topTools}
           />
         }
@@ -1217,6 +1229,7 @@ export default function ScapeEditor() {
           <>
             <div className="mr-2 flex items-center gap-1 border-r border-border/50 pr-4">
               <div
+                data-tour="auto-toggle"
                 className={cn(
                   "mr-2 flex items-center gap-2",
                   !isRunning && "pointer-events-none opacity-50"
@@ -1233,6 +1246,7 @@ export default function ScapeEditor() {
               {/* Refresh (Only when Running) */}
               {isRunning && (
                 <Button
+                  data-tour="quick-run-button"
                   variant="ghost"
                   size="sm"
                   onClick={handleManualRefresh}
@@ -1247,6 +1261,7 @@ export default function ScapeEditor() {
               <div className="flex items-center gap-2">
                 {/* Stop / Start with Rotate Effect on Run */}
                 <Button
+                  data-tour="run-button"
                   // Logic for Run button:
                   // Primary/default state is "Run" (Green)
                   // Active state is "Stop" (Red)
@@ -1630,17 +1645,19 @@ export default function ScapeEditor() {
                                   // 2. Handle Text Code
                                   if (typeof activeFile.content === "string") {
                                     return (
-                                      <CodeEditor
-                                        key={activeFile.name}
-                                        fileName={activeFile.name}
-                                        initialValue={activeFile.content as string}
-                                        language={activeFile.language}
-                                        onChange={handleCodeChange}
-                                        onValidate={handleValidate}
-                                        files={deferredFiles}
-                                        onRun={handleRun}
-                                        editorSettings={editorSettings}
-                                      />
+                                      <div data-tour="code-editor" className="h-full">
+                                        <CodeEditor
+                                          key={activeFile.name}
+                                          fileName={activeFile.name}
+                                          initialValue={activeFile.content as string}
+                                          language={activeFile.language}
+                                          onChange={handleCodeChange}
+                                          onValidate={handleValidate}
+                                          files={deferredFiles}
+                                          onRun={handleRun}
+                                          editorSettings={editorSettings}
+                                        />
+                                      </div>
                                     )
                                   }
 
@@ -1673,102 +1690,106 @@ export default function ScapeEditor() {
                               )}
                             </ResizablePanel>
                             <ResizableHandle className={!isTerminalOpen ? "hidden" : ""} />
-                            {isTerminalOpen && (
-                              <ResizablePanel
-                                defaultSize={getLayout("codescape:layout:vertical", [75, 25])[1]}
-                                minSize={10}
-                              >
-                                <TerminalPane
-                                  activeTab={terminalTab}
-                                  onTabChange={handleTerminalTabChange}
-                                  onClose={() => setIsTerminalOpen(false)}
-                                  problems={problems}
-                                  isCollapsed={false}
-                                  files={files}
-                                  scapeName={scape?.name}
-                                  scapeId={id}
-                                  onDeleteFile={deleteFileDirectly}
-                                  onCreateFile={handleCreateFile}
-                                  onUpdateFile={async (name, content) => updateFile(name, content)}
-                                  outputLogs={outputLogs}
-                                  onExecCommand={handleExecCommand}
-                                  inputPrompt={inputPrompt}
-                                  onInputSubmit={handleInputSubmit}
-                                  isRunning={isRunning}
-                                  isWaitingForTerminalInput={isWaitingForTerminalInput}
-                                  terminalInputPrompt={terminalInputPrompt}
-                                  onTerminalInputSubmit={handleTerminalInputSubmit}
-                                  isPythonRunning={isPythonRunning}
-                                  // Scapper environment awareness
-                                  environment={
-                                    scape?.environment
-                                      ? {
-                                          id: scape.environment,
-                                          name:
-                                            ENVIRONMENTS[scape.environment]?.name ||
-                                            scape.environment,
-                                          entryPoint:
-                                            ENVIRONMENTS[scape.environment]?.entryPoint ||
-                                            "index.html",
-                                          capabilities:
-                                            ENVIRONMENTS[scape.environment]?.capabilities || {},
-                                        }
-                                      : undefined
-                                  }
-                                  dependencies={optimisticDependencies ?? scape?.dependencies ?? []}
-                                  // Scapper execution tools
-                                  runFile={
-                                    scape?.environment === "python"
-                                      ? async (path) => {
-                                          let stdout = ""
-                                          let stderr = ""
-                                          if (previewRef.current?.runFile) {
-                                            await previewRef.current.runFile(path, {
-                                              files: files
-                                                .filter((f) => typeof f.content === "string")
-                                                .map((f) => ({
-                                                  name: f.name,
-                                                  content: f.content as string,
-                                                  language: f.language,
-                                                })),
-                                              onOutput: (content, type) => {
-                                                if (type === "stderr") {
-                                                  stderr += content
-                                                } else {
-                                                  stdout += content
-                                                }
-                                              },
-                                            })
+                            {
+                              isTerminalOpen && (
+                                <ResizablePanel
+                                  defaultSize={getLayout("codescape:layout:vertical", [75, 25])[1]}
+                                  minSize={10}
+                                >
+                                  <div data-tour="terminal-pane" className="h-full">
+                                    <TerminalPane
+                                      activeTab={terminalTab}
+                                      onTabChange={handleTerminalTabChange}
+                                      onClose={() => setIsTerminalOpen(false)}
+                                      problems={problems}
+                                      isCollapsed={false}
+                                      files={files}
+                                      scapeName={scape?.name}
+                                      scapeId={id}
+                                      onDeleteFile={deleteFileDirectly}
+                                      onCreateFile={handleCreateFile}
+                                      onUpdateFile={async (name, content) => updateFile(name, content)}
+                                      outputLogs={outputLogs}
+                                      onExecCommand={handleExecCommand}
+                                      inputPrompt={inputPrompt}
+                                      onInputSubmit={handleInputSubmit}
+                                      isRunning={isRunning}
+                                      isWaitingForTerminalInput={isWaitingForTerminalInput}
+                                      terminalInputPrompt={terminalInputPrompt}
+                                      onTerminalInputSubmit={handleTerminalInputSubmit}
+                                      isPythonRunning={isPythonRunning}
+                                      // Scapper environment awareness
+                                      environment={
+                                        scape?.environment
+                                          ? {
+                                            id: scape.environment,
+                                            name:
+                                              ENVIRONMENTS[scape.environment]?.name ||
+                                              scape.environment,
+                                            entryPoint:
+                                              ENVIRONMENTS[scape.environment]?.entryPoint ||
+                                              "index.html",
+                                            capabilities:
+                                              ENVIRONMENTS[scape.environment]?.capabilities || {},
                                           }
-                                          return { stdout, stderr }
-                                        }
-                                      : undefined
-                                  }
-                                  installPackage={
-                                    scape?.environment === "python"
-                                      ? async (name, onProgress) => {
-                                          const result = await handleExecCommand(
-                                            "pip-install",
-                                            name,
-                                            onProgress
-                                          )
-                                          return {
-                                            success: result.success,
-                                            logs: "",
-                                            error: result.error,
+                                          : undefined
+                                      }
+                                      dependencies={optimisticDependencies ?? scape?.dependencies ?? []}
+                                      // Scapper execution tools
+                                      runFile={
+                                        scape?.environment === "python"
+                                          ? async (path) => {
+                                            let stdout = ""
+                                            let stderr = ""
+                                            if (previewRef.current?.runFile) {
+                                              await previewRef.current.runFile(path, {
+                                                files: files
+                                                  .filter((f) => typeof f.content === "string")
+                                                  .map((f) => ({
+                                                    name: f.name,
+                                                    content: f.content as string,
+                                                    language: f.language,
+                                                  })),
+                                                onOutput: (content, type) => {
+                                                  if (type === "stderr") {
+                                                    stderr += content
+                                                  } else {
+                                                    stdout += content
+                                                  }
+                                                },
+                                              })
+                                            }
+                                            return { stdout, stderr }
                                           }
-                                        }
-                                      : undefined
-                                  }
-                                  listPackages={
-                                    scape?.environment === "python"
-                                      ? async () =>
-                                          (await previewRef.current?.listPackages?.()) ?? []
-                                      : undefined
-                                  }
-                                />
-                              </ResizablePanel>
-                            )}
+                                          : undefined
+                                      }
+                                      installPackage={
+                                        scape?.environment === "python"
+                                          ? async (name, onProgress) => {
+                                            const result = await handleExecCommand(
+                                              "pip-install",
+                                              name,
+                                              onProgress
+                                            )
+                                            return {
+                                              success: result.success,
+                                              logs: "",
+                                              error: result.error,
+                                            }
+                                          }
+                                          : undefined
+                                      }
+                                      listPackages={
+                                        scape?.environment === "python"
+                                          ? async () =>
+                                            (await previewRef.current?.listPackages?.()) ?? []
+                                          : undefined
+                                      }
+                                    />
+                                  </div>
+                                </ResizablePanel>
+                              )
+                            }
                           </ResizablePanelGroup>
                         </div>
                         {!isTerminalOpen && (
@@ -1810,6 +1831,7 @@ export default function ScapeEditor() {
                         if (!isPreviewOpen) setIsPreviewOpen(true)
                       }}
                       className={!isPreviewOpen ? "min-w-0" : ""}
+                      data-tour="preview-pane"
                     >
                       <PreviewPane
                         key={id} // Force remount on scape switch
@@ -1890,6 +1912,6 @@ export default function ScapeEditor() {
           }
         }}
       />
-    </>
+    </TourProvider>
   )
 }

--- a/supabase/migrations/20260108_tour_preferences.sql
+++ b/supabase/migrations/20260108_tour_preferences.sql
@@ -1,0 +1,14 @@
+-- Add preferences JSONB column to profiles table for storing user preferences
+-- including tour completion status
+
+-- Add the preferences column if it doesn't exist
+ALTER TABLE public.profiles 
+ADD COLUMN IF NOT EXISTS preferences JSONB DEFAULT '{}'::jsonb;
+
+-- Add a comment explaining the column structure
+COMMENT ON COLUMN public.profiles.preferences IS 
+'User preferences stored as JSONB. Structure: { "completed_tours": ["tour-id-1", "tour-id-2"] }';
+
+-- Create an index on the completed_tours array for efficient lookups (optional but helpful)
+CREATE INDEX IF NOT EXISTS idx_profiles_completed_tours 
+ON public.profiles USING GIN ((preferences -> 'completed_tours'));


### PR DESCRIPTION
- Add opt-in welcome modal for environment tours (Python, Web)
- Tours cover: code editor, file explorer, run/stop, quick run, auto-run, terminal, output pane, packages, secrets
- Use Lucide icons instead of emojis throughout
- User controls pace with Next button (no auto-advance)
- Skip/close/complete all mark tour as dismissed

Persistence:
- Save completed tours to localStorage (synchronous init to prevent race conditions)
- Sync with user profile preferences (Supabase) when logged in
- Merge local and profile data on load

Restart:
- Add help button in sidebar (EditorActivityBar) to restart tour
- TourRestartButtonWrapper triggers restart from sidebar

Migration:
- Add preferences JSONB column to profiles table for storing completed_tours

Note: eslint-disable comments for valid portal mount detection pattern