### PR TITLE
feat(stripe): add dual environment support (test/live)

### DIFF
--- a/supabase/functions/create-payment-intent/index.ts
+++ b/supabase/functions/create-payment-intent/index.ts
@@ -31,17 +31,35 @@ serve(async (req: Request) => {
   }
 
   try {
-    const stripeSecretKey = Deno.env.get("STRIPE_SECRET_KEY")
+    // ================================================================
+    // Dual Environment Support: Test (Sandbox) vs Live (Production)
+    // Set STRIPE_ENV=live in production, defaults to test for safety
+    // ================================================================
+    const stripeEnv = Deno.env.get("STRIPE_ENV") || "test"
+    const isLive = stripeEnv === "live"
+
+    const stripeSecretKey = isLive
+      ? Deno.env.get("STRIPE_SECRET_KEY_LIVE")
+      : Deno.env.get("STRIPE_SECRET_KEY_TEST")
+
+    const priceId = isLive
+      ? Deno.env.get("STRIPE_PRICE_ID_LIVE")
+      : Deno.env.get("STRIPE_PRICE_ID_TEST")
+
     const serviceRoleKey = Deno.env.get("SERVICE_ROLE_KEY")
 
-    if (!stripeSecretKey || !serviceRoleKey) {
+    console.log(`[Payment] Environment: ${stripeEnv}, isLive: ${isLive}`)
+
+    if (!stripeSecretKey || !serviceRoleKey || !priceId) {
       console.error("Missing secrets: ", {
         stripe: !!stripeSecretKey,
         serviceRole: !!serviceRoleKey,
+        priceId: !!priceId,
+        env: stripeEnv,
       })
       return new Response(
         JSON.stringify({
-          error: "Server configuration error: Missing Secrets (Stripe/ServiceRole)",
+          error: `Server configuration error: Missing Secrets for ${stripeEnv} environment`,
         }),
         {
           status: 500,
@@ -132,7 +150,7 @@ serve(async (req: Request) => {
       console.log(`[Payment] Created Stripe customer: ${customerId}`)
     }
 
-    const PRICE_ID = "price_1SnTW3DReSL06oNAt9hFgqAe" // CodeScapes Pro ($9.99/mo)
+    const PRICE_ID = priceId // Now from environment variable
 
     // ================================================================
     // CRITICAL: Check for existing ACTIVE subscriptions to prevent duplicates

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -22,18 +22,35 @@ serve(async (req: Request) => {
   }
 
   try {
-    const stripeSecretKey = Deno.env.get("STRIPE_SECRET_KEY")
-    const stripeWebhookSecret = Deno.env.get("STRIPE_WEBHOOK_SECRET")
+    // ================================================================
+    // Dual Environment Support: Test (Sandbox) vs Live (Production)
+    // Set STRIPE_ENV=live in production, defaults to test for safety
+    // ================================================================
+    const stripeEnv = Deno.env.get("STRIPE_ENV") || "test"
+    const isLive = stripeEnv === "live"
+
+    const stripeSecretKey = isLive
+      ? Deno.env.get("STRIPE_SECRET_KEY_LIVE")
+      : Deno.env.get("STRIPE_SECRET_KEY_TEST")
+
+    const stripeWebhookSecret = isLive
+      ? Deno.env.get("STRIPE_WEBHOOK_SECRET_LIVE")
+      : Deno.env.get("STRIPE_WEBHOOK_SECRET_TEST")
+
+    console.log(`[Webhook] Environment: ${stripeEnv}, isLive: ${isLive}`)
 
     if (!stripeSecretKey || !stripeWebhookSecret) {
-      console.error("[Webhook] Stripe keys not configured:", {
+      console.error(`[Webhook] Stripe keys not configured for ${stripeEnv}:`, {
         hasSecretKey: !!stripeSecretKey,
         hasWebhookSecret: !!stripeWebhookSecret,
       })
-      return new Response(JSON.stringify({ error: "Payment service not configured" }), {
-        status: 500,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      })
+      return new Response(
+        JSON.stringify({ error: `Payment service not configured for ${stripeEnv}` }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      )
     }
 
     // DEBUG: Log secret prefix to verify correct value is loaded

--- a/supabase/functions/sync-subscription/index.ts
+++ b/supabase/functions/sync-subscription/index.ts
@@ -24,16 +24,31 @@ serve(async (req: Request) => {
   }
 
   try {
-    const stripeSecretKey = Deno.env.get("STRIPE_SECRET_KEY")
+    // ================================================================
+    // Dual Environment Support: Test (Sandbox) vs Live (Production)
+    // Set STRIPE_ENV=live in production, defaults to test for safety
+    // ================================================================
+    const stripeEnv = Deno.env.get("STRIPE_ENV") || "test"
+    const isLive = stripeEnv === "live"
+
+    const stripeSecretKey = isLive
+      ? Deno.env.get("STRIPE_SECRET_KEY_LIVE")
+      : Deno.env.get("STRIPE_SECRET_KEY_TEST")
+
     const serviceRoleKey =
       Deno.env.get("SERVICE_ROLE_KEY") || Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")
 
+    console.log(`[Sync] Environment: ${stripeEnv}, isLive: ${isLive}`)
+
     if (!stripeSecretKey || !serviceRoleKey) {
-      console.error("[Sync] Missing secrets")
-      return new Response(JSON.stringify({ error: "Server configuration error" }), {
-        status: 500,
-        headers: { ...corsHeaders, "Content-Type": "application/json" },
-      })
+      console.error(`[Sync] Missing secrets for ${stripeEnv}`)
+      return new Response(
+        JSON.stringify({ error: `Server configuration error for ${stripeEnv}` }),
+        {
+          status: 500,
+          headers: { ...corsHeaders, "Content-Type": "application/json" },
+        }
+      )
     }
 
     // Verify auth


### PR DESCRIPTION
- Add STRIPE_ENV toggle to switch between test and live modes
- Use STRIPE_SECRET_KEY_TEST/LIVE, STRIPE_PRICE_ID_TEST/LIVE
- Use STRIPE_WEBHOOK_SECRET_TEST/LIVE for webhook verification
- Defaults to test mode for safety
- Apply to create-payment-intent, stripe-webhook, sync-subscription